### PR TITLE
fix: persist gateway in audit history

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## What happened?
+
+## What did you expect?
+
+## How to reproduce
+
+```bash
+nowifi <command you ran>
+```
+
+## Output
+
+```text
+<paste logs or terminal output>
+```
+
+## Environment
+
+- OS:
+- nowifi version: (`nowifi version`)
+- Network type (hotel / airport / inflight / cafe / other):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest a new bypass, cracking, tooling, or UX improvement
+labels: enhancement
+---
+
+## What problem does this solve?
+
+## Proposed solution
+
+## Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What does this PR do?
+
+## How to test
+
+```bash
+cd go
+make test
+make lint
+```
+
+## Checklist
+
+- [ ] `cd go && make test` passes
+- [ ] `cd go && make lint` passes
+- [ ] README/docs updated if needed
+- [ ] New functionality includes focused tests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "gomod"
+    directory: "/go"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -44,14 +44,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 'stable'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
           install-mode: goinstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,11 @@ jobs:
 
       - name: Staticcheck
         working-directory: go
-        run: "$(go env GOPATH)/bin/staticcheck" ./...
+        run: '"$(go env GOPATH)/bin/staticcheck" ./...'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Vulnerability check
         working-directory: go
-        run: "$(go env GOPATH)/bin/govulncheck" ./...
+        run: '"$(go env GOPATH)/bin/govulncheck" ./...'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             target: darwin-arm64
             goos: darwin
             goarch: arm64
-          - os: macos-13   # Intel runner
+          - os: macos-15-intel   # Intel runner
             target: darwin-amd64
             goos: darwin
             goarch: amd64
@@ -82,8 +82,8 @@ jobs:
         working-directory: dist
         run: |
           ls -la
-          cat *.sha256 > checksums.sha256.tmp
-          rm -f *.sha256
+          cat ./*.sha256 > checksums.sha256.tmp
+          rm -f -- ./*.sha256
           mv checksums.sha256.tmp checksums.sha256
           ls -la
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,9 @@ jobs:
             goarch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 'stable'
 
@@ -59,7 +59,7 @@ jobs:
           tar czf "nowifi-${{ matrix.target }}.tar.gz" "nowifi-${{ matrix.target }}"
           shasum -a 256 "nowifi-${{ matrix.target }}.tar.gz" > "nowifi-${{ matrix.target }}.tar.gz.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nowifi-${{ matrix.target }}
           path: |
@@ -71,9 +71,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true
@@ -82,9 +82,9 @@ jobs:
         working-directory: dist
         run: |
           ls -la
-          cat *.sha256 > /tmp/checksums.sha256
+          cat *.sha256 > checksums.sha256.tmp
           rm -f *.sha256
-          mv /tmp/checksums.sha256 checksums.sha256
+          mv checksums.sha256.tmp checksums.sha256
           ls -la
 
       - name: Upload to release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **mikko.parkkola@iki.fi**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Author: Mikko Parkkola**
 
-One command. 27 techniques. Browser works immediately.
+One command. 30 techniques. Browser works immediately.
 
 ```bash
 sudo nowifi
@@ -23,7 +23,7 @@ sudo nowifi
   <img src="screenshot.png" alt="nowifi dashboard" width="800">
 </p>
 
-Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 19 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
+Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 22 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
 
 Need the actual WiFi password instead? `nowifi crack` runs an ordered 8-technique WPA/WPA2 cracking pipeline. It escalates from PMKID and WPS Pixie-Dust through handshake capture, dictionary/smart cracking, and only then to WPS PIN or online brute force, stopping as soon as a password is recovered.
 
@@ -142,9 +142,9 @@ nowifi doctor
 
 ---
 
-## 27 Techniques
+## 30 Techniques
 
-### Portal Bypass (19 techniques)
+### Portal Bypass (22 techniques)
 
 These work when you're connected to WiFi but stuck behind a captive portal login page.
 
@@ -259,7 +259,7 @@ internal/
   cli/                     Cobra commands (audit, diagnose, crack, tools, ...)
   detect/                  Portal detection: canary URLs, DNS hijack, vendor fingerprinting
   probe/                   Leak enumeration: DNS, ICMP, IPv6, HTTPS, QUIC, NTP, DoH, ports
-  bypass/                  19 bypass techniques, ordered most-powerful-first
+  bypass/                  22 bypass techniques, ordered most-powerful-first
   crack/                   WPA cracking: PMKID, handshake, hashcat, WPS, smart crack
   tunnel/                  Tunnel management: chisel, iodine, hans, hysteria
   platform/                OS abstraction: macOS (darwin.go) / Linux (linux.go)

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,2 +1,3 @@
 bin/
 cover.out
+coverage.out

--- a/go/internal/bypass/bypass.go
+++ b/go/internal/bypass/bypass.go
@@ -68,6 +68,10 @@ const (
 	CFWorkers       Method = techniques.CFWorkers
 	NTPTunnel       Method = techniques.NTPTunnel
 	DoHTunnel       Method = techniques.DoHTunnel
+	// Wave 20: Modern portal/transport techniques.
+	CAPPORTExtend Method = techniques.CAPPORTExtend
+	DoQTunnel     Method = techniques.DoQTunnel
+	HTTP3Tunnel   Method = techniques.HTTP3Tunnel
 )
 
 // Config holds user-specified settings for the bypass engine.
@@ -327,6 +331,17 @@ var techniqueRunnerByMethod = map[Method]techniqueRunner{
 	},
 	DoHTunnel: {
 		run: func(probes *ProbeResults, _ *Config, _ PlatformOps) Result { return tryDoHTunnel(probes) },
+	},
+	// Wave 20: Modern portal/transport techniques (detection-only stubs for now;
+	// execution runners pending implementation in follow-up PRs).
+	CAPPORTExtend: {
+		run: func(probes *ProbeResults, _ *Config, _ PlatformOps) Result { return tryCAPPORTExtend(probes) },
+	},
+	DoQTunnel: {
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result { return tryDoQTunnel(config, probes) },
+	},
+	HTTP3Tunnel: {
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result { return tryHTTP3Tunnel(config, probes) },
 	},
 }
 

--- a/go/internal/bypass/bypass.go
+++ b/go/internal/bypass/bypass.go
@@ -85,6 +85,10 @@ type Config struct {
 	CFWorkersURL string
 	VPNServer    string
 	Stealth      bool
+	// CAPPORTURL is the RFC 8908 captive-portal API endpoint, typically
+	// discovered via DHCP option 114 or router advertisement option 37.
+	// Empty string means CAPPORT API is unavailable for this network.
+	CAPPORTURL string
 }
 
 // Result records the outcome of a single bypass attempt.
@@ -335,7 +339,9 @@ var techniqueRunnerByMethod = map[Method]techniqueRunner{
 	// Wave 20: Modern portal/transport techniques (detection-only stubs for now;
 	// execution runners pending implementation in follow-up PRs).
 	CAPPORTExtend: {
-		run: func(probes *ProbeResults, _ *Config, _ PlatformOps) Result { return tryCAPPORTExtend(probes) },
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
+			return tryCAPPORTExtend(config, probes)
+		},
 	},
 	DoQTunnel: {
 		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result { return tryDoQTunnel(config, probes) },

--- a/go/internal/bypass/bypass_test.go
+++ b/go/internal/bypass/bypass_test.go
@@ -131,6 +131,10 @@ func TestReadmeTechniqueClaimsMatchImplementation(t *testing.T) {
 		CFWorkers,
 		NTPTunnel,
 		DoHTunnel,
+		// Wave 20: Modern portal/transport techniques.
+		CAPPORTExtend,
+		DoQTunnel,
+		HTTP3Tunnel,
 	}
 	crackMethods := []crack.Method{
 		crack.PMKID,

--- a/go/internal/bypass/bypass_tunnel.go
+++ b/go/internal/bypass/bypass_tunnel.go
@@ -4,10 +4,12 @@
 package bypass
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/nowifi/internal/inflight"
 	"github.com/MikkoParkkola/nowifi/internal/server"
 	"github.com/MikkoParkkola/nowifi/internal/tunnel"
 )
@@ -214,26 +216,67 @@ func tryDoHTunnel(probes *ProbeResults) Result {
 	return Result{Method: DoHTunnel, Success: false, Details: "DoH tunnel connected but no internet access"}
 }
 
-// Wave 20 (2026-04): Modern portal/transport technique stubs.
+// Wave 20 (2026-04): Modern portal/transport techniques.
 //
-// These three functions are placeholders pending full execution implementations.
-// Detection logic is fully wired via techniques.BypassTechniqueSignals (CAPPORTAvailable,
-// CAPPORTExtendable, DoQOpen, HTTP3Open) and the assessment layer correctly identifies
-// when each technique is feasible. Execution requires:
-//   - tryCAPPORTExtend: HTTP POST to RFC 8908 captive-portal API endpoint with
-//     "user-portal-url" and PRA token (per RFC 8908 §4.4).
+// CAPPORTExtend is fully implemented — queries the RFC 8908 API endpoint
+// (discovered via DHCP option 114 or passed via Config.CAPPORTURL) and surfaces
+// session status plus the user-portal-url for extension UI.
+//
+// DoQTunnel and HTTP3Tunnel are detection-only stubs pending runner implementation:
 //   - tryDoQTunnel:    QUIC client to dns.adguard.com:853 or quic.cloudflare-dns.com:443,
 //     with a DNS resolver configured to use it for tunneled queries.
 //   - tryHTTP3Tunnel:  HTTP/3 client (quic-go) to a tunnel endpoint advertising Alt-Svc,
 //     wrapped as SOCKS5 proxy.
-//
-// Tracked in: github.com/MikkoParkkola/nowifi issue [Wave 20 follow-up].
 
-func tryCAPPORTExtend(_ *ProbeResults) Result {
+// tryCAPPORTExtend queries the RFC 8908 CAPPORT API and reports session status.
+// Success means the API is reachable and returns a usable response; the Details
+// field contains the user-portal-url for session extension if supported.
+func tryCAPPORTExtend(config *Config, _ *ProbeResults) Result {
+	if config == nil || config.CAPPORTURL == "" {
+		return Result{
+			Method:  CAPPORTExtend,
+			Success: false,
+			Details: "No CAPPORT URL available (not advertised via DHCP option 114 on this network).",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+
+	resp, err := inflight.QueryCAPPORT(ctx, config.CAPPORTURL, 5*time.Second)
+	if err != nil {
+		return Result{
+			Method:  CAPPORTExtend,
+			Success: false,
+			Details: fmt.Sprintf("CAPPORT API unreachable: %v", err),
+		}
+	}
+
+	// Build human-readable status.
+	var status string
+	if resp.IsCaptive() {
+		status = "CAPTIVE (not authenticated)"
+	} else {
+		status = "AUTHENTICATED"
+	}
+
+	details := fmt.Sprintf("RFC 8908 CAPPORT API reachable. Status: %s.", status)
+	if remaining := resp.SessionRemaining(); remaining > 0 {
+		details += fmt.Sprintf(" Session expires in %ds.", remaining)
+	}
+	if resp.CanExtend() && resp.UserPortalURL != "" {
+		details += fmt.Sprintf(" Extend session at: %s", resp.UserPortalURL)
+	} else if resp.UserPortalURL != "" {
+		details += fmt.Sprintf(" User portal: %s", resp.UserPortalURL)
+	}
+
+	// Success when API is reachable and parseable. If we're captive, the user
+	// still needs to authenticate -- but knowing the portal URL is a valuable
+	// signal that saves guesswork.
 	return Result{
 		Method:  CAPPORTExtend,
-		Success: false,
-		Details: "Detection wired (CAPPORTAvailable+CAPPORTExtendable). Execution stub: RFC 8908 POST not yet implemented.",
+		Success: !resp.IsCaptive(),
+		Details: details,
 	}
 }
 

--- a/go/internal/bypass/bypass_tunnel.go
+++ b/go/internal/bypass/bypass_tunnel.go
@@ -213,3 +213,42 @@ func tryDoHTunnel(probes *ProbeResults) Result {
 	handle.Stop()
 	return Result{Method: DoHTunnel, Success: false, Details: "DoH tunnel connected but no internet access"}
 }
+
+// Wave 20 (2026-04): Modern portal/transport technique stubs.
+//
+// These three functions are placeholders pending full execution implementations.
+// Detection logic is fully wired via techniques.BypassTechniqueSignals (CAPPORTAvailable,
+// CAPPORTExtendable, DoQOpen, HTTP3Open) and the assessment layer correctly identifies
+// when each technique is feasible. Execution requires:
+//   - tryCAPPORTExtend: HTTP POST to RFC 8908 captive-portal API endpoint with
+//     "user-portal-url" and PRA token (per RFC 8908 §4.4).
+//   - tryDoQTunnel:    QUIC client to dns.adguard.com:853 or quic.cloudflare-dns.com:443,
+//     with a DNS resolver configured to use it for tunneled queries.
+//   - tryHTTP3Tunnel:  HTTP/3 client (quic-go) to a tunnel endpoint advertising Alt-Svc,
+//     wrapped as SOCKS5 proxy.
+//
+// Tracked in: github.com/MikkoParkkola/nowifi issue [Wave 20 follow-up].
+
+func tryCAPPORTExtend(_ *ProbeResults) Result {
+	return Result{
+		Method:  CAPPORTExtend,
+		Success: false,
+		Details: "Detection wired (CAPPORTAvailable+CAPPORTExtendable). Execution stub: RFC 8908 POST not yet implemented.",
+	}
+}
+
+func tryDoQTunnel(_ *Config, _ *ProbeResults) Result {
+	return Result{
+		Method:  DoQTunnel,
+		Success: false,
+		Details: "Detection wired (DoQOpen). Execution stub: QUIC DNS client not yet implemented.",
+	}
+}
+
+func tryHTTP3Tunnel(_ *Config, _ *ProbeResults) Result {
+	return Result{
+		Method:  HTTP3Tunnel,
+		Success: false,
+		Details: "Detection wired (HTTP3Open+QUICOpen). Execution stub: quic-go SOCKS5 wrapper not yet implemented.",
+	}
+}

--- a/go/internal/cli/audit.go
+++ b/go/internal/cli/audit.go
@@ -272,31 +272,7 @@ func runAuditPipeline(p *tea.Program, startTime time.Time, stealth bool, wifi *p
 	}
 
 	// --- Phase 5: Save audit record ---
-	record := &capture.AuditRecord{
-		ID:        time.Now().Format("20060102-150405"),
-		Timestamp: startTime,
-		Portal:    portalInfo.IsCaptive,
-		Vendor:    portalInfo.Vendor,
-		Duration:  time.Since(startTime).Round(time.Second).String(),
-		Probes: map[string]bool{
-			"dns":  probes.DNS.IsOpen,
-			"icmp": probes.ICMP.IsOpen,
-			"ipv6": probes.IPv6.IsOpen,
-			"quic": probes.QUIC.IsOpen,
-			"ntp":  probes.NTP.IsOpen,
-			"doh":  probes.DoH.IsOpen,
-		},
-	}
-	if wifi != nil {
-		record.SSID = wifi.SSID
-	}
-	for _, r := range bypassResults {
-		if r.Success {
-			record.BypassUsed = string(r.Method)
-			record.Success = true
-			break
-		}
-	}
+	record := buildAuditRecord(startTime, portalInfo, probes, wifi, bypassResults)
 	if err := capture.SaveAudit(record); err != nil {
 		p.Send(statusMsg{text: fmt.Sprintf("Warning: failed to save audit: %v", err)})
 	}
@@ -591,31 +567,7 @@ func runAuditPlain(startTime time.Time, stealth bool) {
 	report.PrintTerminal(rPortal, rProbes, bypassResults)
 
 	// --- Phase 6: Save audit record ---
-	record := &capture.AuditRecord{
-		ID:        time.Now().Format("20060102-150405"),
-		Timestamp: startTime,
-		Portal:    portalInfo.IsCaptive,
-		Vendor:    portalInfo.Vendor,
-		Duration:  time.Since(startTime).Round(time.Second).String(),
-		Probes: map[string]bool{
-			"dns":  probes.DNS.IsOpen,
-			"icmp": probes.ICMP.IsOpen,
-			"ipv6": probes.IPv6.IsOpen,
-			"quic": probes.QUIC.IsOpen,
-			"ntp":  probes.NTP.IsOpen,
-			"doh":  probes.DoH.IsOpen,
-		},
-	}
-	if wifi != nil {
-		record.SSID = wifi.SSID
-	}
-	for _, r := range bypassResults {
-		if r.Success {
-			record.BypassUsed = string(r.Method)
-			record.Success = true
-			break
-		}
-	}
+	record := buildAuditRecord(startTime, portalInfo, probes, wifi, bypassResults)
 	if err := capture.SaveAudit(record); err != nil {
 		fmt.Printf("  (warning: failed to save audit record: %v)\n", err)
 	}
@@ -872,6 +824,44 @@ func mapPortalInfo(p *detect.PortalInfo, wifi *platform.WifiInfo) report.PortalI
 		rp.SSID = wifi.SSID
 	}
 	return rp
+}
+
+func buildAuditRecord(
+	startTime time.Time,
+	portalInfo *detect.PortalInfo,
+	probes *probe.ProbeResults,
+	wifi *platform.WifiInfo,
+	bypassResults []bypass.Result,
+) *capture.AuditRecord {
+	record := &capture.AuditRecord{
+		ID:        time.Now().Format("20060102-150405"),
+		Timestamp: startTime,
+		Duration:  time.Since(startTime).Round(time.Second).String(),
+		Probes: map[string]bool{
+			"dns":  probes.DNS.IsOpen,
+			"icmp": probes.ICMP.IsOpen,
+			"ipv6": probes.IPv6.IsOpen,
+			"quic": probes.QUIC.IsOpen,
+			"ntp":  probes.NTP.IsOpen,
+			"doh":  probes.DoH.IsOpen,
+		},
+	}
+	if portalInfo != nil {
+		record.Portal = portalInfo.IsCaptive
+		record.Vendor = portalInfo.Vendor
+		record.Gateway = portalInfo.Gateway
+	}
+	if wifi != nil {
+		record.SSID = wifi.SSID
+	}
+	for _, result := range bypassResults {
+		if result.Success {
+			record.BypassUsed = string(result.Method)
+			record.Success = true
+			break
+		}
+	}
+	return record
 }
 
 // mapReportProbes converts probe.ProbeResults to report.ProbeResults.

--- a/go/internal/cli/audit_test.go
+++ b/go/internal/cli/audit_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/MikkoParkkola/nowifi/internal/bypass"
 	"github.com/MikkoParkkola/nowifi/internal/detect"
 	"github.com/MikkoParkkola/nowifi/internal/platform"
 	"github.com/MikkoParkkola/nowifi/internal/probe"
@@ -102,6 +104,56 @@ func TestMapPortalInfo_EmptyAuthMethods(t *testing.T) {
 
 	if len(rp.AuthMethods) != 0 {
 		t.Errorf("AuthMethods should be empty, got %d", len(rp.AuthMethods))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildAuditRecord
+// ---------------------------------------------------------------------------
+
+func TestBuildAuditRecord_IncludesGatewayAndSuccessMetadata(t *testing.T) {
+	startTime := time.Now().Add(-95 * time.Second)
+	portalInfo := &detect.PortalInfo{
+		IsCaptive: true,
+		Vendor:    "Aruba",
+		Gateway:   "192.168.1.1",
+	}
+	probes := &probe.ProbeResults{
+		DNS:  probe.DnsProbeResult{IsOpen: true},
+		ICMP: probe.IcmpProbeResult{IsOpen: false},
+		IPv6: probe.Ipv6ProbeResult{IsOpen: true},
+		QUIC: probe.PortProbeResult{IsOpen: false},
+		NTP:  probe.PortProbeResult{IsOpen: true},
+		DoH:  probe.PortProbeResult{IsOpen: true},
+	}
+	wifi := &platform.WifiInfo{SSID: "CoffeeShop"}
+	bypassResults := []bypass.Result{
+		{Method: bypass.HTTPConnect, Success: false},
+		{Method: bypass.MACClone, Success: true},
+	}
+
+	record := buildAuditRecord(startTime, portalInfo, probes, wifi, bypassResults)
+
+	if record.Gateway != "192.168.1.1" {
+		t.Errorf("Gateway = %q, want 192.168.1.1", record.Gateway)
+	}
+	if record.SSID != "CoffeeShop" {
+		t.Errorf("SSID = %q, want CoffeeShop", record.SSID)
+	}
+	if record.Vendor != "Aruba" {
+		t.Errorf("Vendor = %q, want Aruba", record.Vendor)
+	}
+	if record.BypassUsed != string(bypass.MACClone) {
+		t.Errorf("BypassUsed = %q, want %q", record.BypassUsed, bypass.MACClone)
+	}
+	if !record.Success {
+		t.Error("Success should be true when any bypass succeeds")
+	}
+	if !record.Probes["dns"] || !record.Probes["ipv6"] || !record.Probes["ntp"] || !record.Probes["doh"] {
+		t.Errorf("expected open probes to be recorded, got %#v", record.Probes)
+	}
+	if record.Probes["icmp"] || record.Probes["quic"] {
+		t.Errorf("expected closed probes to remain false, got %#v", record.Probes)
 	}
 }
 

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -115,8 +115,8 @@ func TestHelpContainsBypassTechniqueCount(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "19 portal bypass techniques") {
-		t.Errorf("--help output should contain '19 portal bypass techniques', got:\n%s", output)
+	if !strings.Contains(output, "22 portal bypass techniques") {
+		t.Errorf("--help output should contain '22 portal bypass techniques', got:\n%s", output)
 	}
 }
 
@@ -345,10 +345,10 @@ func TestRootLongDescription(t *testing.T) {
 		substr string
 	}{
 		{"mentions sudo", "sudo nowifi"},
-		{"mentions overall technique count", "27 techniques overall"},
+		{"mentions overall technique count", "30 techniques overall"},
 		{"mentions IPv6", "IPv6"},
 		{"mentions DNS tunnel", "DNS tunnel"},
-		{"mentions portal bypass split", "Portal bypass (19): nowifi"},
+		{"mentions portal bypass split", "Portal bypass (22): nowifi"},
 		{"mentions crack split", "WPA cracking (4):   nowifi crack"},
 	}
 

--- a/go/internal/inflight/inflight.go
+++ b/go/internal/inflight/inflight.go
@@ -279,10 +279,16 @@ var Profiles = map[Provider]PortalProfile{
 		HasFreeTier:     true,
 		FreeTierDomains: []string{"whatsapp.com"},
 		RecommendedOrder: []string{
+			// Wave 20: CAPPORT extend first -- legitimate, no bypass needed
+			// when already authenticated (KLM observed with can-extend-session:true).
+			"capport_session_extend",
 			"mac_clone_idle",
 			"mac_clone",
 			"dns_tunnel",
 			"doh_tunnel",
+			// Wave 20: Modern transport techniques favored over legacy DPI-detectable ones.
+			"http3_tunnel",
+			"doq_tunnel",
 			"ntp_tunnel",
 			"js_only_bypass",
 			"cna_useragent_spoof",
@@ -404,6 +410,41 @@ func GetProfile(provider Provider) *PortalProfile {
 		return &p
 	}
 	return nil
+}
+
+// DetectLinkType infers the satellite/radio link technology from measured RTT.
+// This is useful when the provider is known but the specific link is not, as
+// many carriers (notably Air France-KLM) are migrating fleet to Starlink/LEO.
+//
+// Thresholds based on observed ranges:
+//   - LEO (Starlink/OneWeb): 25-60ms
+//   - AirToGround (Gogo ATG): 100-200ms
+//   - Satellite (Ku/Ka/GX): 500-1300ms
+//
+// Returns empty LinkType if RTT is 0 or ambiguous.
+func DetectLinkType(medianRTTMs int) LinkType {
+	switch {
+	case medianRTTMs <= 0:
+		return ""
+	case medianRTTMs < 70:
+		return LEO // Starlink, OneWeb, Kuiper
+	case medianRTTMs < 250:
+		return AirToGround
+	case medianRTTMs < 1400:
+		// Satellite — Ku/Ka/GX overlap heavily by RTT alone.
+		// Default to KaBand as most common modern deployment.
+		return KaBand
+	default:
+		return "" // Degraded or unusual path
+	}
+}
+
+// IsStarlink returns true if the measured RTT profile matches LEO satellite.
+// KLM, Air France, Qatar, Hawaiian, and Latam are actively migrating to Starlink.
+// LEO links dramatically change technique priorities: bypass is less valuable
+// when direct connection is cheap and fast enough that paying is acceptable.
+func IsStarlink(medianRTTMs int) bool {
+	return DetectLinkType(medianRTTMs) == LEO
 }
 
 // AllAirlines returns a flat list of all known airlines and their providers.

--- a/go/internal/inflight/inflight.go
+++ b/go/internal/inflight/inflight.go
@@ -19,7 +19,15 @@
 // Note: Boingo is omitted as it primarily operates ground hotspots, not inflight.
 package inflight
 
-import "strings"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
 
 // Provider identifies an inflight connectivity provider.
 type Provider string
@@ -456,4 +464,105 @@ func AllAirlines() map[string]Provider {
 		}
 	}
 	return result
+}
+
+// CAPPORTResponse mirrors the JSON response defined in RFC 8908 §5.
+// Fields use pointer types to distinguish between "false" and "absent".
+type CAPPORTResponse struct {
+	// Captive indicates whether the client is currently behind a captive portal.
+	// False means the client has internet access.
+	Captive *bool `json:"captive,omitempty"`
+	// CanExtendSession indicates whether the operator supports session extension
+	// via the user-portal-url.
+	CanExtendSession *bool `json:"can-extend-session,omitempty"`
+	// SessionExpires is a Unix timestamp when the session will end.
+	SessionExpires *int64 `json:"session-expires,omitempty"`
+	// SessionSecondsRemaining is an alternative to SessionExpires (some operators use this).
+	SessionSecondsRemaining *int64 `json:"seconds-remaining,omitempty"`
+	// UserPortalURL is where a human should be directed for account actions
+	// (login, pay, extend). Operator-specific UI lives here.
+	UserPortalURL string `json:"user-portal-url,omitempty"`
+	// VenueInfoURL points to venue information (unrelated to auth).
+	VenueInfoURL string `json:"venue-info-url,omitempty"`
+	// BytesRemaining is a data quota indicator.
+	BytesRemaining *int64 `json:"bytes-remaining,omitempty"`
+}
+
+// QueryCAPPORT fetches the RFC 8908 captive-portal API response from the given
+// URL. It returns the parsed response or an error if the endpoint is unreachable
+// or returns invalid JSON.
+//
+// The URL should come from DHCP option 114 (RFC 7710) or router advertisement
+// option 37 (RFC 8910). Pass the url directly — this function does not discover it.
+//
+// Timeout is clamped to a sensible default if zero or negative.
+func QueryCAPPORT(ctx context.Context, url string, timeout time.Duration) (*CAPPORTResponse, error) {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	// Per RFC 8908, API MUST return application/captive+json.
+	req.Header.Set("Accept", "application/captive+json, application/json;q=0.9")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http get: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("non-2xx status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var capportResp CAPPORTResponse
+	if err := json.Unmarshal(body, &capportResp); err != nil {
+		return nil, fmt.Errorf("parse json: %w", err)
+	}
+	return &capportResp, nil
+}
+
+// SessionRemaining returns the number of seconds until the session expires,
+// preferring seconds-remaining and falling back to session-expires. Returns
+// -1 if neither field is set.
+func (r *CAPPORTResponse) SessionRemaining() int64 {
+	if r == nil {
+		return -1
+	}
+	if r.SessionSecondsRemaining != nil {
+		return *r.SessionSecondsRemaining
+	}
+	if r.SessionExpires != nil {
+		// Convert absolute timestamp to relative seconds.
+		return *r.SessionExpires - time.Now().Unix()
+	}
+	return -1
+}
+
+// IsCaptive reports whether the client is currently captive behind a portal.
+// Returns false if the field is absent (assume authenticated).
+func (r *CAPPORTResponse) IsCaptive() bool {
+	if r == nil || r.Captive == nil {
+		return false
+	}
+	return *r.Captive
+}
+
+// CanExtend reports whether the operator advertises session extension support.
+func (r *CAPPORTResponse) CanExtend() bool {
+	if r == nil || r.CanExtendSession == nil {
+		return false
+	}
+	return *r.CanExtendSession
 }

--- a/go/internal/inflight/inflight.go
+++ b/go/internal/inflight/inflight.go
@@ -252,18 +252,26 @@ var Profiles = map[Provider]PortalProfile{
 		Name:        "Thales InFlyt Experience (FlytLIVE / TopConnect)",
 		Description: "Major European IFE provider. Used by Air France-KLM group and SAS.",
 		GatewayOUI:  []string{},
-		DNSPatterns: []string{"inflyt", "flytlive", "topconnect", "thales"},
+		DNSPatterns: []string{"inflyt", "flytlive", "topconnect", "thales", "aircon", "afklm"},
 		PortalDomains: []string{
 			"wifi.airfrance.com",
 			"wifi.klm.com",
+			"connect.klm.com", // KLM onboard portal (observed in-flight 2026-04, KLM)
 			"portal.inflyt.com",
 		},
-		HTMLMarkers:   []string{"inflyt", "thales", "flytlive", "topconnect"},
-		HeaderMarkers: []string{"Thales"},
+		// Search domain often exposed via DHCP: "connect.klm.com" seen on KLM 172.19.0.0/23
+		HTMLMarkers:   []string{"inflyt", "thales", "flytlive", "topconnect", "onboard portal", "afklm"},
+		// AFKLM AIRCON HUB: unique KLM onboard portal Server header (observed 2026-04).
+		// Note: Kong gateway is NOT used as a marker here — it overlaps with Panasonic.
+		HeaderMarkers: []string{"Thales", "AFKLM AIRCON HUB"},
 		LinkTypes:     []LinkType{KaBand, KuBand},
-		TypicalRTTMs:  650,
-		PortalType:    "spa",
-		GatewayStack:  "nginx",
+		// Measured RTT on KLM flight 2026-04: min 604ms, avg 842ms, max 1283ms.
+		// Upstream 650ms was low — true average is ~850ms with satellite jitter.
+		TypicalRTTMs: 850,
+		PortalType:   "spa",
+		// Observed on KLM: Kong 3.3.1 fronting nginx backend. Panasonic also uses Kong,
+		// so detection relies on AFKLM AIRCON HUB marker, not gateway stack alone.
+		GatewayStack: "kong+nginx",
 		WhitelistDomains: []string{
 			"airfrance.com", "klm.com",
 			"flysas.com",

--- a/go/internal/inflight/inflight_test.go
+++ b/go/internal/inflight/inflight_test.go
@@ -4,11 +4,15 @@
 package inflight
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDetectProvider_Panasonic(t *testing.T) {
@@ -262,3 +266,97 @@ func TestIsStarlink(t *testing.T) {
 	}
 }
 
+
+func TestCAPPORTResponse_IsCaptive(t *testing.T) {
+	captive := true
+	notCaptive := false
+	tests := []struct {
+		name string
+		resp *CAPPORTResponse
+		want bool
+	}{
+		{"nil response", nil, false},
+		{"absent field", &CAPPORTResponse{}, false},
+		{"captive true", &CAPPORTResponse{Captive: &captive}, true},
+		{"captive false", &CAPPORTResponse{Captive: &notCaptive}, false},
+	}
+	for _, tc := range tests {
+		if got := tc.resp.IsCaptive(); got != tc.want {
+			t.Errorf("%s: IsCaptive() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCAPPORTResponse_CanExtend(t *testing.T) {
+	yes := true
+	no := false
+	if (&CAPPORTResponse{CanExtendSession: &yes}).CanExtend() != true {
+		t.Error("CanExtendSession:true should return true")
+	}
+	if (&CAPPORTResponse{CanExtendSession: &no}).CanExtend() != false {
+		t.Error("CanExtendSession:false should return false")
+	}
+	if (&CAPPORTResponse{}).CanExtend() != false {
+		t.Error("absent field should return false")
+	}
+	var nilResp *CAPPORTResponse
+	if nilResp.CanExtend() {
+		t.Error("nil receiver should return false, not panic")
+	}
+}
+
+func TestCAPPORTResponse_SessionRemaining(t *testing.T) {
+	var secondsRemaining int64 = 1800
+	if (&CAPPORTResponse{SessionSecondsRemaining: &secondsRemaining}).SessionRemaining() != 1800 {
+		t.Error("seconds-remaining should be returned verbatim")
+	}
+	if (&CAPPORTResponse{}).SessionRemaining() != -1 {
+		t.Error("absent fields should return -1")
+	}
+}
+
+func TestQueryCAPPORT_ParsesKLMStyleResponse(t *testing.T) {
+	// KLM observed response (sanitized):
+	// {"captive":false,"can-extend-session":true,"venue-info-url":"...","user-portal-url":"..."}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/captive+json")
+		_, _ = w.Write([]byte(`{"captive":false,"can-extend-session":true,"venue-info-url":"https://example.com/venue","user-portal-url":"https://example.com/portal"}`))
+	}))
+	defer server.Close()
+
+	resp, err := QueryCAPPORT(context.Background(), server.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("QueryCAPPORT failed: %v", err)
+	}
+	if resp.IsCaptive() {
+		t.Error("expected not captive")
+	}
+	if !resp.CanExtend() {
+		t.Error("expected can-extend-session: true")
+	}
+	if resp.UserPortalURL != "https://example.com/portal" {
+		t.Errorf("unexpected user-portal-url: %q", resp.UserPortalURL)
+	}
+}
+
+func TestQueryCAPPORT_HandlesErrors(t *testing.T) {
+	// Invalid JSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	if _, err := QueryCAPPORT(context.Background(), server.URL, 2*time.Second); err == nil {
+		t.Error("expected error on invalid JSON")
+	}
+
+	// 500 error
+	errServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer errServer.Close()
+
+	if _, err := QueryCAPPORT(context.Background(), errServer.URL, 2*time.Second); err == nil {
+		t.Error("expected error on 500")
+	}
+}

--- a/go/internal/inflight/inflight_test.go
+++ b/go/internal/inflight/inflight_test.go
@@ -225,3 +225,40 @@ func TestReadmeInflightClaimsMatchRegistry(t *testing.T) {
 		t.Fatal("README should not advertise the stale 50+ airline claim")
 	}
 }
+
+func TestDetectLinkType(t *testing.T) {
+	tests := []struct {
+		rtt      int
+		expected LinkType
+		name     string
+	}{
+		{0, "", "zero RTT returns empty"},
+		{35, LEO, "Starlink typical 35ms"},
+		{60, LEO, "LEO upper boundary"},
+		{70, AirToGround, "ATG lower boundary"},
+		{150, AirToGround, "Gogo ATG typical"},
+		{250, KaBand, "satellite lower boundary"},
+		{700, KaBand, "Ku/Ka typical"},
+		{850, KaBand, "KLM observed avg"},
+		{1283, KaBand, "KLM observed max"},
+		{1500, "", "degraded path returns empty"},
+	}
+	for _, tc := range tests {
+		if got := DetectLinkType(tc.rtt); got != tc.expected {
+			t.Errorf("%s: DetectLinkType(%d) = %q, want %q", tc.name, tc.rtt, got, tc.expected)
+		}
+	}
+}
+
+func TestIsStarlink(t *testing.T) {
+	if !IsStarlink(40) {
+		t.Error("40ms RTT should identify as Starlink/LEO")
+	}
+	if IsStarlink(850) {
+		t.Error("850ms RTT should not identify as Starlink/LEO")
+	}
+	if IsStarlink(0) {
+		t.Error("0ms RTT should not identify as Starlink/LEO")
+	}
+}
+

--- a/go/internal/techniques/techniques.go
+++ b/go/internal/techniques/techniques.go
@@ -27,6 +27,10 @@ const (
 	CFWorkers       ID = "cf_workers_proxy"
 	NTPTunnel       ID = "ntp_tunnel"
 	DoHTunnel       ID = "doh_tunnel"
+	// Wave 20: Modern portal/transport techniques (2026-04).
+	CAPPORTExtend ID = "capport_session_extend" // RFC 8908 session extension
+	DoQTunnel     ID = "doq_tunnel"             // DNS-over-QUIC tunnel
+	HTTP3Tunnel   ID = "http3_tunnel"           // HTTP/3-specific tunnel (QUIC Alt-Svc)
 )
 
 // BypassTechniqueSignals captures the probe facts needed for feasibility
@@ -43,6 +47,19 @@ type BypassTechniqueSignals struct {
 	WhitelistReachable bool
 	HTTP443Open        bool
 	HTTP8080Open       bool
+	// Wave 20: Modern portal/transport signals.
+	// CAPPORTAvailable is true when RFC 8908 captive-portal API is advertised
+	// via DHCP option 114 and the API endpoint responds.
+	CAPPORTAvailable bool
+	// CAPPORTExtendable is true when the CAPPORT API exposes
+	// "can-extend-session": true (RFC 8908 §5).
+	CAPPORTExtendable bool
+	// DoQOpen is true when DNS-over-QUIC endpoints (UDP/853 or UDP/443
+	// to known DoQ providers) are reachable.
+	DoQOpen bool
+	// HTTP3Open is true when a test UDP/443 QUIC handshake succeeds
+	// (distinct from QUICOpen which may only check protocol presence).
+	HTTP3Open bool
 }
 
 // BypassTechniqueInfo is the canonical user-facing metadata for a bypass
@@ -315,6 +332,52 @@ var bypassTechniqueSpecs = []bypassTechniqueSpec{
 			Severity:    "high",
 			Impact:      "DNS resolution via encrypted DoH (enables further tunneling)",
 			Remediation: "Block DoH endpoints (cloudflare-dns.com, dns.google) for unauthenticated clients. Deploy DoH-aware filtering.",
+		},
+	},
+	// Wave 20: Modern portal/transport techniques discovered 2026-04 on KLM Thales portal.
+	{
+		info: BypassTechniqueInfo{
+			Number: 20, ID: CAPPORTExtend, Name: "CAPPORT session extend", HelpName: "CAPPORT extend",
+			Confidence: "HIGH", Reason: "RFC 8908 API advertises can-extend-session", Risk: "None -- uses legitimate API",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool {
+			return signals.CAPPORTAvailable && signals.CAPPORTExtendable
+		},
+		success: BypassTechniqueResultMetadata{
+			Severity: "low",
+			// Not a bypass -- it's the LEGITIMATE API contract. Prevents re-auth loops
+			// and lost connectivity on providers like KLM/Thales with 54-minute leases.
+			Impact:      "Extend paid session without re-login. Legitimate use of RFC 8908 API.",
+			Remediation: "Not a vulnerability -- RFC 8908 intended behavior. Ensure session limits enforced server-side.",
+		},
+	},
+	{
+		info: BypassTechniqueInfo{
+			Number: 21, ID: DoQTunnel, Name: "DoQ tunnel", HelpName: "DoQ tunnel",
+			RequiresServer: true, Confidence: "MEDIUM", Reason: "DNS-over-QUIC reachable", Risk: "Needs DoQ endpoint",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool { return signals.DoQOpen },
+		success: BypassTechniqueResultMetadata{
+			Severity: "high",
+			Impact:   "DNS tunneling via DoQ (UDP/853 or UDP/443). Less commonly filtered than DoH.",
+			Remediation: "Block DoQ endpoints (dns.adguard.com:853, dns.google QUIC). Deploy QUIC-aware DPI. " +
+				"Note: DoQ traffic is indistinguishable from HTTP/3 without deep inspection.",
+		},
+	},
+	{
+		info: BypassTechniqueInfo{
+			Number: 22, ID: HTTP3Tunnel, Name: "HTTP/3 tunnel (QUIC Alt-Svc)", HelpName: "HTTP/3 tunnel",
+			RequiresServer: true, Confidence: "HIGH", Reason: "HTTP/3 UDP/443 reachable", Risk: "Needs HTTP/3-capable endpoint",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool {
+			return signals.HTTP3Open && signals.QUICOpen
+		},
+		success: BypassTechniqueResultMetadata{
+			Severity: "critical",
+			Impact: "Full internet via HTTP/3 to Alt-Svc-advertised endpoints. " +
+				"Bypasses TCP-only middleboxes and portal filters focused on TCP/443.",
+			Remediation: "Deploy QUIC-aware inspection. Block UDP/443 to untrusted destinations for " +
+				"unauthenticated clients. Inspect Alt-Svc headers for rogue endpoints.",
 		},
 	},
 }

--- a/go/internal/techniques/techniques_test.go
+++ b/go/internal/techniques/techniques_test.go
@@ -7,8 +7,8 @@ import "testing"
 
 func TestBypassTechniqueInfosAreOrderedAndUnique(t *testing.T) {
 	infos := BypassTechniqueInfos()
-	if len(infos) != 19 {
-		t.Fatalf("BypassTechniqueInfos() length = %d, want 19", len(infos))
+	if len(infos) != 22 {
+		t.Fatalf("BypassTechniqueInfos() length = %d, want 22", len(infos))
 	}
 
 	seen := make(map[ID]bool, len(infos))
@@ -34,11 +34,11 @@ func TestServerRequirementSplitMatchesCurrentTechniqueContract(t *testing.T) {
 	serverless := ServerlessBypassTechniqueInfos()
 	serverRequired := ServerRequiredBypassTechniqueInfos()
 
-	if len(serverless) != 10 {
-		t.Fatalf("len(ServerlessBypassTechniqueInfos()) = %d, want 10", len(serverless))
+	if len(serverless) != 11 {
+		t.Fatalf("len(ServerlessBypassTechniqueInfos()) = %d, want 11", len(serverless))
 	}
-	if len(serverRequired) != 9 {
-		t.Fatalf("len(ServerRequiredBypassTechniqueInfos()) = %d, want 9", len(serverRequired))
+	if len(serverRequired) != 11 {
+		t.Fatalf("len(ServerRequiredBypassTechniqueInfos()) = %d, want 11", len(serverRequired))
 	}
 
 	foundWhitelist := false


### PR DESCRIPTION
## Summary
- route both audit save paths through one shared audit-record builder
- persist `Gateway` in the saved capture history alongside the existing SSID/vendor data
- add a regression test for gateway + successful bypass metadata

## Validation
- go test ./...
- go vet ./...