### PR TITLE
feat(bypass): Wave 21 #23 — DHCP Option 121 route bypass (CVE-2024-3661)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Author: Mikko Parkkola**
 
-One command. 30 techniques. Browser works immediately.
+One command. 31 techniques. Browser works immediately.
 
 ```bash
 sudo nowifi
@@ -23,7 +23,7 @@ sudo nowifi
   <img src="screenshot.png" alt="nowifi dashboard" width="800">
 </p>
 
-Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 22 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
+Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 23 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
 
 Need the actual WiFi password instead? `nowifi crack` runs an ordered 8-technique WPA/WPA2 cracking pipeline. It escalates from PMKID and WPS Pixie-Dust through handshake capture, dictionary/smart cracking, and only then to WPS PIN or online brute force, stopping as soon as a password is recovered.
 
@@ -146,9 +146,9 @@ nowifi doctor
 
 ---
 
-## 30 Techniques
+## 31 Techniques
 
-### Portal Bypass (22 techniques)
+### Portal Bypass (23 techniques)
 
 These work when you're connected to WiFi but stuck behind a captive portal login page.
 
@@ -176,6 +176,7 @@ These work when you're connected to WiFi but stuck behind a captive portal login
 | 20 | **CAPPORT extend** | RFC 8908 captive-portal API — surfaces session state and user-portal URL | Medium |
 | 21 | **DoQ tunnel** | DNS-over-QUIC (RFC 9250) to public resolver, bypasses DNS interception | High |
 | 22 | **HTTP/3 tunnel** | Pure-Go QUIC tunnel with ALPN `h3` on UDP/443, SOCKS5 wrapper | Critical |
+| 23 | **DHCP Option 121 route** | CVE-2024-3661 "TunnelVision" — honor DHCP-advertised static routes that bypass the portal's filter chain (serverless) | High |
 
 ### WPA Cracking (4 techniques)
 
@@ -183,19 +184,19 @@ These crack the actual WiFi password when you don't have it. The stages run in o
 
 | # | Technique | How it works |
 |---|-----------|-------------|
-| 23 | **PMKID capture** | Extract PMKID from AP's first message -- no clients needed (~60% of APs) |
-| 24 | **WPS Pixie-Dust** | Exploit weak RNG in WPS (~30% of WPS-enabled APs, 5-30s) |
-| 25 | **Handshake capture + hashcat** | Deauth a client, capture 4-way handshake, GPU crack |
-| 26 | **WPS PIN brute force** | Brute force 11,000 PIN combinations (2-10 hours, last resort) |
+| 24 | **PMKID capture** | Extract PMKID from AP's first message -- no clients needed (~60% of APs) |
+| 25 | **WPS Pixie-Dust** | Exploit weak RNG in WPS (~30% of WPS-enabled APs, 5-30s) |
+| 26 | **Handshake capture + hashcat** | Deauth a client, capture 4-way handshake, GPU crack |
+| 27 | **WPS PIN brute force** | Brute force 11,000 PIN combinations (2-10 hours, last resort) |
 
 ### Smart Cracking (4 additional strategies)
 
 | # | Technique | How it works |
 |---|-----------|-------------|
-| 27 | **Smart common passwords** | Top 1000 WiFi passwords (embedded, no wordlist needed) |
-| 28 | **Numeric mask attack** | 8-digit patterns common in ISP-issued routers |
-| 29 | **Word+number rules** | Hashcat rules combining dictionary words with numbers |
-| 30 | **Online brute force** | wpa_supplicant PSK attempts (no monitor mode needed) |
+| 28 | **Smart common passwords** | Top 1000 WiFi passwords (embedded, no wordlist needed) |
+| 29 | **Numeric mask attack** | 8-digit patterns common in ISP-issued routers |
+| 30 | **Word+number rules** | Hashcat rules combining dictionary words with numbers |
+| 31 | **Online brute force** | wpa_supplicant PSK attempts (no monitor mode needed) |
 
 The smart-crack pipeline also runs dictionary, smart-brute, and (opt-in) full-brute stages between rules and online brute force, in increasing cost order.
 

--- a/go/internal/bypass/bypass.go
+++ b/go/internal/bypass/bypass.go
@@ -72,6 +72,8 @@ const (
 	CAPPORTExtend Method = techniques.CAPPORTExtend
 	DoQTunnel     Method = techniques.DoQTunnel
 	HTTP3Tunnel   Method = techniques.HTTP3Tunnel
+	// Wave 21: serverless DHCP-advertised route injection.
+	DHCPRouteBypass Method = techniques.DHCPRouteBypass
 )
 
 // Config holds user-specified settings for the bypass engine.
@@ -96,6 +98,11 @@ type Config struct {
 	// DoQServer is a DNS-over-QUIC endpoint in host:port form.
 	// Defaults to dns.adguard.com:853 when empty.
 	DoQServer string
+	// DHCPClasslessRoutes holds RFC 3442 option 121 routes advertised by
+	// the DHCP server on Interface. Populated by the audit pipeline from
+	// platform.GetDHCPClasslessRoutes at probe time. Non-default routes
+	// here enable the Wave 21 #23 DHCPRouteBypass technique.
+	DHCPClasslessRoutes []platform.DHCPRoute
 }
 
 // Result records the outcome of a single bypass attempt.
@@ -208,8 +215,8 @@ type PlatformOps interface {
 	GenerateRandomMAC() string
 }
 
-// RunBypasses tries all 19 bypass techniques in order, stopping on the
-// first success. Returns the list of all attempted results.
+// RunBypasses tries every registered bypass technique in order, stopping on
+// the first success. Returns the list of all attempted results.
 func RunBypasses(probes *ProbeResults, config *Config, plat PlatformOps) []Result {
 	if plat == nil {
 		plat = &defaultPlatformOps{}
@@ -356,6 +363,12 @@ var techniqueRunnerByMethod = map[Method]techniqueRunner{
 	HTTP3Tunnel: {
 		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
 			return tryHTTP3Tunnel(config, probes)
+		},
+	},
+	// Wave 21: DHCP-advertised static route injection.
+	DHCPRouteBypass: {
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
+			return tryDHCPRouteBypass(config, probes)
 		},
 	},
 }

--- a/go/internal/bypass/bypass_dhcp_route.go
+++ b/go/internal/bypass/bypass_dhcp_route.go
@@ -1,0 +1,160 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package bypass
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/platform"
+)
+
+// ---------------------------------------------------------------------------
+// Wave 21 #23 — DHCP Option 121 static-route bypass (CVE-2024-3661 primitive).
+//
+// Some captive-portal gateways enforce policy only in the default-route chain
+// (iptables PREROUTING / pf rdr rules tied to the default gateway's interface
+// and subnet). An RFC 3442 option-121 classless static route advertised via
+// DHCP can install a *second* path to the outside world, one that the portal
+// filter chain doesn't cover.
+//
+// We don't spoof DHCP here — we just honor what the network itself advertised.
+// When the DHCP lease already includes a non-default option-121 route, we:
+//
+//  1. Pick the narrowest non-default route (least likely to disrupt the user).
+//  2. Install it via platform.AddRoute.
+//  3. Probe internet access (HTTP 204 to gstatic) through the new path.
+//  4. Leave the route in place on success; guard package cleanup removes it
+//     on exit. Roll back on failure so we never leave the user worse off.
+//
+// The technique only triggers when Config.DHCPClasslessRoutes contains at
+// least one non-default entry, populated by the audit pipeline via
+// platform.GetDHCPClasslessRoutes(iface). There is no active DHCP spoofing.
+// ---------------------------------------------------------------------------
+
+// dhcpRouteVerifyURL is the connectivity-check URL. Overridable by tests.
+var dhcpRouteVerifyURL = "http://connectivitycheck.gstatic.com/generate_204"
+
+// platformAddRoute / platformDeleteRoute are package-level indirections so
+// tests can inject stubs without mocking the whole platform package.
+var (
+	platformAddRoute    = platform.AddRoute
+	platformDeleteRoute = platform.DeleteRoute
+)
+
+// tryDHCPRouteBypass attempts the Wave 21 #23 technique. Returns a Result
+// with Success=true iff a non-default route was added and gstatic/generate_204
+// returns 204 afterwards.
+func tryDHCPRouteBypass(config *Config, _ *ProbeResults) Result {
+	if config == nil || len(config.DHCPClasslessRoutes) == 0 {
+		return Result{
+			Method:  DHCPRouteBypass,
+			Success: false,
+			Details: "DHCP option 121 not advertised on this network.",
+		}
+	}
+
+	candidates := filterNonDefaultRoutes(config.DHCPClasslessRoutes)
+	if len(candidates) == 0 {
+		return Result{
+			Method:  DHCPRouteBypass,
+			Success: false,
+			Details: "DHCP option 121 present but only default route advertised (no bypass primitive).",
+		}
+	}
+
+	// Try candidates narrowest-first (highest prefix length). Narrower routes
+	// are safer: they affect less of the user's traffic if the gateway
+	// doesn't actually provide internet.
+	candidates = sortByPrefixDesc(candidates)
+
+	var attempts []string
+	for _, route := range candidates {
+		attempts = append(attempts, fmt.Sprintf("%s via %s", route.CIDR, route.Gateway))
+		if err := platformAddRoute(route.CIDR, route.Gateway); err != nil {
+			continue
+		}
+
+		if dhcpRouteInternetReachable() {
+			return successResult(
+				DHCPRouteBypass,
+				fmt.Sprintf("DHCP-advertised route %s via %s bypasses portal filter. "+
+					"Internet reachable via this path without authentication.",
+					route.CIDR, route.Gateway),
+			)
+		}
+
+		// No internet via this route -- roll back before trying next.
+		_ = platformDeleteRoute(route.CIDR)
+	}
+
+	return Result{
+		Method:  DHCPRouteBypass,
+		Success: false,
+		Details: "Tried " + strings.Join(attempts, ", ") + " — none provided external connectivity.",
+	}
+}
+
+// filterNonDefaultRoutes drops the default route (0.0.0.0/0) which the system
+// already uses; only narrower routes can give a bypass primitive.
+func filterNonDefaultRoutes(in []platform.DHCPRoute) []platform.DHCPRoute {
+	out := make([]platform.DHCPRoute, 0, len(in))
+	for _, r := range in {
+		if r.IsDefault() || r.Gateway == "" || r.CIDR == "" {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(r.CIDR); err != nil {
+			continue
+		}
+		if net.ParseIP(r.Gateway) == nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// sortByPrefixDesc returns routes ordered by prefix length descending
+// (most-specific first).
+func sortByPrefixDesc(in []platform.DHCPRoute) []platform.DHCPRoute {
+	out := make([]platform.DHCPRoute, len(in))
+	copy(out, in)
+	// Simple insertion sort; expected len <= ~8.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && prefixLen(out[j]) > prefixLen(out[j-1]); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+func prefixLen(r platform.DHCPRoute) int {
+	_, n, err := net.ParseCIDR(r.CIDR)
+	if err != nil {
+		return 0
+	}
+	ones, _ := n.Mask.Size()
+	return ones
+}
+
+// dhcpRouteInternetReachable hits the Google captive-portal check URL and
+// reports whether it returns HTTP 204 within a short deadline.
+func dhcpRouteInternetReachable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dhcpRouteVerifyURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := internetCheckClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode == 204
+}

--- a/go/internal/bypass/bypass_dhcp_route_test.go
+++ b/go/internal/bypass/bypass_dhcp_route_test.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package bypass
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MikkoParkkola/nowifi/internal/platform"
+)
+
+// TestDHCPRouteBypass_NoRoutes verifies the technique reports failure when
+// DHCP option 121 is not advertised, without touching the routing table.
+func TestDHCPRouteBypass_NoRoutes(t *testing.T) {
+	var addCalled, delCalled int32
+	platformAddRoute = func(string, string) error { atomic.AddInt32(&addCalled, 1); return nil }
+	platformDeleteRoute = func(string) error { atomic.AddInt32(&delCalled, 1); return nil }
+	defer resetDHCPRouteStubs()
+
+	r := tryDHCPRouteBypass(&Config{}, nil)
+	if r.Success {
+		t.Fatalf("expected failure when no routes; got success: %+v", r)
+	}
+	if atomic.LoadInt32(&addCalled) != 0 || atomic.LoadInt32(&delCalled) != 0 {
+		t.Errorf("unexpected route mutation: add=%d del=%d", addCalled, delCalled)
+	}
+	if !strings.Contains(r.Details, "not advertised") {
+		t.Errorf("details should mention not advertised, got %q", r.Details)
+	}
+}
+
+// TestDHCPRouteBypass_OnlyDefaultRoute verifies we do NOT attempt to install
+// a 0.0.0.0/0 route (the system already has one; installing another would be
+// dangerous and provides no bypass primitive).
+func TestDHCPRouteBypass_OnlyDefaultRoute(t *testing.T) {
+	var addCalled int32
+	platformAddRoute = func(string, string) error { atomic.AddInt32(&addCalled, 1); return nil }
+	platformDeleteRoute = func(string) error { return nil }
+	defer resetDHCPRouteStubs()
+
+	cfg := &Config{
+		DHCPClasslessRoutes: []platform.DHCPRoute{
+			{CIDR: "0.0.0.0/0", Gateway: "192.168.1.1"},
+		},
+	}
+	r := tryDHCPRouteBypass(cfg, nil)
+	if r.Success {
+		t.Fatal("expected failure with only default route")
+	}
+	if atomic.LoadInt32(&addCalled) != 0 {
+		t.Errorf("must not AddRoute for default route; got %d calls", addCalled)
+	}
+	if !strings.Contains(r.Details, "only default route") {
+		t.Errorf("details should mention only default route, got %q", r.Details)
+	}
+}
+
+// TestDHCPRouteBypass_Success exercises the full happy path: a non-default
+// route is advertised, AddRoute succeeds, the verify HTTP check returns 204,
+// and the technique reports success. DeleteRoute must NOT be called.
+func TestDHCPRouteBypass_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	origURL := dhcpRouteVerifyURL
+	dhcpRouteVerifyURL = srv.URL
+	defer func() { dhcpRouteVerifyURL = origURL }()
+
+	var addArgs, delArgs []string
+	platformAddRoute = func(cidr, gw string) error {
+		addArgs = append(addArgs, cidr+"|"+gw)
+		return nil
+	}
+	platformDeleteRoute = func(cidr string) error {
+		delArgs = append(delArgs, cidr)
+		return nil
+	}
+	defer resetDHCPRouteStubs()
+
+	cfg := &Config{
+		DHCPClasslessRoutes: []platform.DHCPRoute{
+			{CIDR: "0.0.0.0/0", Gateway: "192.168.1.1"}, // must be skipped
+			{CIDR: "8.8.8.8/32", Gateway: "192.168.1.2"},
+		},
+	}
+	r := tryDHCPRouteBypass(cfg, nil)
+	if !r.Success {
+		t.Fatalf("expected success; got %+v", r)
+	}
+	if len(addArgs) != 1 || addArgs[0] != "8.8.8.8/32|192.168.1.2" {
+		t.Errorf("expected single AddRoute(8.8.8.8/32, 192.168.1.2); got %v", addArgs)
+	}
+	if len(delArgs) != 0 {
+		t.Errorf("must not DeleteRoute on success; got %v", delArgs)
+	}
+}
+
+// TestDHCPRouteBypass_RollbackOnNoInternet verifies that when AddRoute
+// succeeds but the verify check does NOT return 204, the route is deleted.
+func TestDHCPRouteBypass_RollbackOnNoInternet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // portal-style 500
+	}))
+	defer srv.Close()
+
+	origURL := dhcpRouteVerifyURL
+	dhcpRouteVerifyURL = srv.URL
+	defer func() { dhcpRouteVerifyURL = origURL }()
+
+	var addCalled, delCalled int32
+	platformAddRoute = func(string, string) error { atomic.AddInt32(&addCalled, 1); return nil }
+	platformDeleteRoute = func(string) error { atomic.AddInt32(&delCalled, 1); return nil }
+	defer resetDHCPRouteStubs()
+
+	cfg := &Config{
+		DHCPClasslessRoutes: []platform.DHCPRoute{
+			{CIDR: "10.0.0.0/8", Gateway: "192.168.1.9"},
+		},
+	}
+	r := tryDHCPRouteBypass(cfg, nil)
+	if r.Success {
+		t.Fatal("expected failure when verify URL returns 500")
+	}
+	if atomic.LoadInt32(&addCalled) != 1 {
+		t.Errorf("expected one AddRoute; got %d", addCalled)
+	}
+	if atomic.LoadInt32(&delCalled) != 1 {
+		t.Errorf("expected rollback DeleteRoute; got %d", delCalled)
+	}
+}
+
+// TestDHCPRouteBypass_PrefersNarrowestRoute verifies that narrower routes
+// are attempted first — they're safer: a /32 affects one host, a /8 many.
+func TestDHCPRouteBypass_PrefersNarrowestRoute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	origURL := dhcpRouteVerifyURL
+	dhcpRouteVerifyURL = srv.URL
+	defer func() { dhcpRouteVerifyURL = origURL }()
+
+	var firstAdded string
+	platformAddRoute = func(cidr, _ string) error {
+		if firstAdded == "" {
+			firstAdded = cidr
+		}
+		return nil
+	}
+	platformDeleteRoute = func(string) error { return nil }
+	defer resetDHCPRouteStubs()
+
+	cfg := &Config{
+		DHCPClasslessRoutes: []platform.DHCPRoute{
+			{CIDR: "10.0.0.0/8", Gateway: "192.168.1.9"},
+			{CIDR: "8.8.8.8/32", Gateway: "192.168.1.9"},
+			{CIDR: "172.16.0.0/12", Gateway: "192.168.1.9"},
+		},
+	}
+	if r := tryDHCPRouteBypass(cfg, nil); !r.Success {
+		t.Fatalf("expected success; got %+v", r)
+	}
+	if firstAdded != "8.8.8.8/32" {
+		t.Errorf("expected narrowest route first; got %q", firstAdded)
+	}
+}
+
+// TestFilterNonDefaultRoutes verifies input sanitation: malformed CIDRs or
+// gateways are dropped before we ever touch the kernel routing table.
+func TestFilterNonDefaultRoutes(t *testing.T) {
+	in := []platform.DHCPRoute{
+		{CIDR: "0.0.0.0/0", Gateway: "1.1.1.1"},      // default -- drop
+		{CIDR: "10.0.0.0/8", Gateway: ""},            // empty gw -- drop
+		{CIDR: "", Gateway: "1.1.1.1"},               // empty cidr -- drop
+		{CIDR: "not-a-cidr", Gateway: "1.1.1.1"},     // bad cidr -- drop
+		{CIDR: "10.0.0.0/8", Gateway: "not-an-ip"},   // bad gw -- drop
+		{CIDR: "10.0.0.0/8", Gateway: "192.168.1.1"}, // keep
+	}
+	out := filterNonDefaultRoutes(in)
+	if len(out) != 1 || out[0].CIDR != "10.0.0.0/8" {
+		t.Errorf("filter returned %v, want single 10.0.0.0/8", out)
+	}
+}
+
+func resetDHCPRouteStubs() {
+	platformAddRoute = platform.AddRoute
+	platformDeleteRoute = platform.DeleteRoute
+}

--- a/go/internal/bypass/bypass_test.go
+++ b/go/internal/bypass/bypass_test.go
@@ -135,6 +135,8 @@ func TestReadmeTechniqueClaimsMatchImplementation(t *testing.T) {
 		CAPPORTExtend,
 		DoQTunnel,
 		HTTP3Tunnel,
+		// Wave 21: serverless DHCP-advertised route injection.
+		DHCPRouteBypass,
 	}
 	crackMethods := []crack.Method{
 		crack.PMKID,

--- a/go/internal/cli/audit.go
+++ b/go/internal/cli/audit.go
@@ -233,20 +233,23 @@ func runAuditPipeline(p *tea.Program, startTime time.Time, stealth bool, wifi *p
 	// --- Phase 4: Bypass ---
 	// Discover RFC 8908 CAPPORT URL from DHCP option 114 (non-fatal if absent).
 	capportURL, _ := platform.GetCAPPORTURL(flagInterface)
+	// Discover RFC 3442 option 121 routes (non-fatal if absent) for Wave 21 #23.
+	dhcpRoutes, _ := platform.GetDHCPClasslessRoutes(flagInterface)
 
 	bpConfig := &bypass.Config{
-		Interface:    flagInterface,
-		TunnelServer: flagTunnelServer,
-		DNSDomain:    flagDNSDomain,
-		ICMPServer:   flagICMPServer,
-		QUICServer:   flagQUICServer,
-		NTPServer:    flagNTPServer,
-		VPNServer:    flagVPNServer,
-		CFWorkersURL: flagCFWorkers,
-		CAPPORTURL:   capportURL,
-		HTTP3Server:  flagHTTP3Server,
-		DoQServer:    flagDoQServer,
-		Stealth:      stealth,
+		Interface:           flagInterface,
+		TunnelServer:        flagTunnelServer,
+		DNSDomain:           flagDNSDomain,
+		ICMPServer:          flagICMPServer,
+		QUICServer:          flagQUICServer,
+		NTPServer:           flagNTPServer,
+		VPNServer:           flagVPNServer,
+		CFWorkersURL:        flagCFWorkers,
+		CAPPORTURL:          capportURL,
+		HTTP3Server:         flagHTTP3Server,
+		DoQServer:           flagDoQServer,
+		DHCPClasslessRoutes: dhcpRoutes,
+		Stealth:             stealth,
 	}
 
 	p.Send(statusMsg{text: "Running bypass techniques..."})

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -115,8 +115,8 @@ func TestHelpContainsBypassTechniqueCount(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "22 portal bypass techniques") {
-		t.Errorf("--help output should contain '22 portal bypass techniques', got:\n%s", output)
+	if !strings.Contains(output, "23 portal bypass techniques") {
+		t.Errorf("--help output should contain '23 portal bypass techniques', got:\n%s", output)
 	}
 }
 
@@ -345,10 +345,10 @@ func TestRootLongDescription(t *testing.T) {
 		substr string
 	}{
 		{"mentions sudo", "sudo nowifi"},
-		{"mentions overall technique count", "30 techniques overall"},
+		{"mentions overall technique count", "31 techniques overall"},
 		{"mentions IPv6", "IPv6"},
 		{"mentions DNS tunnel", "DNS tunnel"},
-		{"mentions portal bypass split", "Portal bypass (22): nowifi"},
+		{"mentions portal bypass split", "Portal bypass (23): nowifi"},
 		{"mentions crack split", "WPA cracking (4):   nowifi crack"},
 	}
 

--- a/go/internal/platform/darwin.go
+++ b/go/internal/platform/darwin.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -802,4 +803,86 @@ func GetDNSSearchDomain(iface string) (string, error) {
 		return domain, nil
 	}
 	return "", nil
+}
+
+// GetDHCPClasslessRoutes returns DHCP option 121 (RFC 3442) classless static
+// routes advertised on the given interface. Empty slice when not advertised.
+//
+// macOS `ipconfig getpacket <iface>` emits option 121 as either:
+//
+//	classless_static_route (ip_mult): {10.0.0.0/8, 192.168.1.1}, {0.0.0.0/0, 192.168.1.1}
+//	option_121 (dhcp_option): ...
+//
+// We accept both field names.
+func GetDHCPClasslessRoutes(iface string) ([]DHCPRoute, error) {
+	if _, err := ValidateInterface(iface); err != nil {
+		return nil, fmt.Errorf("get dhcp routes: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "ipconfig", "getpacket", iface).Output()
+	if err != nil {
+		return nil, fmt.Errorf("ipconfig getpacket: %w", err)
+	}
+
+	return parseClasslessStaticRoutes(string(out)), nil
+}
+
+// parseClasslessStaticRoutes extracts {cidr, gateway} pairs from a single
+// `classless_static_route (...)` or `option_121 (...)` line. Exposed for tests.
+func parseClasslessStaticRoutes(out string) []DHCPRoute {
+	// Match the whole option line so we can then pull pairs out of it.
+	lineRE := regexp.MustCompile(`(?i)(classless_static_route|option_121)\s*\([^)]+\):\s*(.+)`)
+	pairRE := regexp.MustCompile(`\{\s*([\d\.]+/\d+)\s*,\s*([\d\.]+)\s*\}`)
+	var routes []DHCPRoute
+	for _, m := range lineRE.FindAllStringSubmatch(out, -1) {
+		payload := m[2]
+		for _, pm := range pairRE.FindAllStringSubmatch(payload, -1) {
+			routes = append(routes, DHCPRoute{CIDR: pm[1], Gateway: pm[2]})
+		}
+	}
+	return routes
+}
+
+// AddRoute installs an IPv4 route on macOS via `route add -net CIDR GW`.
+// Idempotent: "route already in table" is not treated as error.
+func AddRoute(cidr, gateway string) error {
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		return fmt.Errorf("add route: invalid cidr %q: %w", cidr, err)
+	}
+	if net.ParseIP(gateway) == nil {
+		return fmt.Errorf("add route: invalid gateway %q", gateway)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "route", "-n", "add", "-net", cidr, gateway).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "File exists") || strings.Contains(msg, "already in table") {
+			return nil
+		}
+		return fmt.Errorf("route add: %w: %s", err, msg)
+	}
+	return nil
+}
+
+// DeleteRoute removes an IPv4 route previously added via AddRoute.
+// Missing route is not treated as error.
+func DeleteRoute(cidr string) error {
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		return fmt.Errorf("delete route: invalid cidr %q: %w", cidr, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "route", "-n", "delete", "-net", cidr).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "not in table") {
+			return nil
+		}
+		return fmt.Errorf("route delete: %w: %s", err, msg)
+	}
+	return nil
 }

--- a/go/internal/platform/dhcp_route_darwin_test.go
+++ b/go/internal/platform/dhcp_route_darwin_test.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package platform
+
+import "testing"
+
+func TestParseClasslessStaticRoutes_Darwin(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []DHCPRoute
+	}{
+		{
+			name: "standard ipconfig format",
+			in: "op = BOOTREPLY\n" +
+				"classless_static_route (ip_mult): {10.0.0.0/8, 192.168.1.1}, {0.0.0.0/0, 192.168.1.1}\n" +
+				"server_identifier (ip): 192.168.1.1\n",
+			want: []DHCPRoute{
+				{CIDR: "10.0.0.0/8", Gateway: "192.168.1.1"},
+				{CIDR: "0.0.0.0/0", Gateway: "192.168.1.1"},
+			},
+		},
+		{
+			name: "option_121 alias",
+			in:   "option_121 (dhcp_option): {172.16.0.0/12, 10.0.0.1}\n",
+			want: []DHCPRoute{{CIDR: "172.16.0.0/12", Gateway: "10.0.0.1"}},
+		},
+		{
+			name: "no option 121",
+			in:   "op = BOOTREPLY\nserver_identifier (ip): 192.168.1.1\n",
+			want: nil,
+		},
+		{
+			name: "single route only",
+			in:   "classless_static_route (ip_mult): {8.8.8.8/32, 10.0.0.1}\n",
+			want: []DHCPRoute{{CIDR: "8.8.8.8/32", Gateway: "10.0.0.1"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseClasslessStaticRoutes(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/internal/platform/dhcp_route_linux_test.go
+++ b/go/internal/platform/dhcp_route_linux_test.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package platform
+
+import "testing"
+
+func TestParseLinuxClasslessRoutes_Dhcpcd(t *testing.T) {
+	in := "new_classless_static_routes='10.0.0.0/8 192.168.1.1 0.0.0.0/0 192.168.1.1'\n"
+	got := parseLinuxClasslessRoutes(in)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2; got %v", len(got), got)
+	}
+	if got[0].CIDR != "10.0.0.0/8" || got[0].Gateway != "192.168.1.1" {
+		t.Errorf("[0] = %+v", got[0])
+	}
+	if got[1].CIDR != "0.0.0.0/0" || got[1].Gateway != "192.168.1.1" {
+		t.Errorf("[1] = %+v", got[1])
+	}
+}
+
+func TestParseLinuxClasslessRoutes_Systemd(t *testing.T) {
+	in := "ADDRESS=192.168.1.55\nCLASSLESS_STATIC_ROUTES=172.16.0.0/12 10.0.0.1\n"
+	got := parseLinuxClasslessRoutes(in)
+	if len(got) != 1 || got[0].CIDR != "172.16.0.0/12" || got[0].Gateway != "10.0.0.1" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseLinuxClasslessRoutes_DhclientHex(t *testing.T) {
+	// prefix=8 dest=10 gw=192.168.1.1 → "8:a:c0:a8:1:1"
+	// prefix=0 gw=192.168.1.1 → "0:c0:a8:1:1"
+	in := "option rfc3442-classless-static-routes 8:a:c0:a8:1:1, 0:c0:a8:1:1;\n"
+	got := parseLinuxClasslessRoutes(in)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2; got %v", len(got), got)
+	}
+	if got[0].CIDR != "10.0.0.0/8" || got[0].Gateway != "192.168.1.1" {
+		t.Errorf("[0] = %+v, want 10.0.0.0/8 via 192.168.1.1", got[0])
+	}
+	if got[1].CIDR != "0.0.0.0/0" || got[1].Gateway != "192.168.1.1" {
+		t.Errorf("[1] = %+v, want 0.0.0.0/0 via 192.168.1.1", got[1])
+	}
+}
+
+func TestParseLinuxClasslessRoutes_NoOption(t *testing.T) {
+	got := parseLinuxClasslessRoutes("ADDRESS=192.168.1.55\nROUTER=192.168.1.1\n")
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}

--- a/go/internal/platform/dhcp_route_test.go
+++ b/go/internal/platform/dhcp_route_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+//go:build darwin || linux
+
+package platform
+
+import "testing"
+
+func TestDHCPRoute_IsDefault(t *testing.T) {
+	tests := []struct {
+		in   DHCPRoute
+		want bool
+	}{
+		{DHCPRoute{CIDR: "0.0.0.0/0"}, true},
+		{DHCPRoute{CIDR: "::/0"}, true},
+		{DHCPRoute{CIDR: "10.0.0.0/8"}, false},
+		{DHCPRoute{CIDR: ""}, false},
+	}
+	for _, tc := range tests {
+		if got := tc.in.IsDefault(); got != tc.want {
+			t.Errorf("IsDefault(%q) = %v, want %v", tc.in.CIDR, got, tc.want)
+		}
+	}
+}

--- a/go/internal/platform/linux.go
+++ b/go/internal/platform/linux.go
@@ -8,6 +8,7 @@ package platform
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -802,4 +803,163 @@ func GetDNSSearchDomain(iface string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// GetDHCPClasslessRoutes returns DHCP option 121 (RFC 3442) classless static
+// routes advertised on the given interface, read from the active DHCP lease
+// file. Empty slice when not advertised or no lease found.
+//
+// dhclient emits:
+//
+//	option rfc3442-classless-static-routes 8:a:1:1:1, 0:c0:a8:1:1;
+//
+// dhcpcd emits:
+//
+//	new_classless_static_routes='10.0.0.0/8 192.168.1.1 0.0.0.0/0 192.168.1.1'
+//
+// systemd-networkd writes a key=value file:
+//
+//	CLASSLESS_STATIC_ROUTES=10.0.0.0/8 192.168.1.1 0.0.0.0/0 192.168.1.1
+//
+// We support all three formats.
+func GetDHCPClasslessRoutes(iface string) ([]DHCPRoute, error) {
+	if _, err := ValidateInterface(iface); err != nil {
+		return nil, fmt.Errorf("get dhcp routes: %w", err)
+	}
+
+	candidates := []string{
+		fmt.Sprintf("/var/lib/dhcp/dhclient.%s.leases", iface),
+		fmt.Sprintf("/var/lib/dhcpcd/%s.lease", iface),
+		fmt.Sprintf("/run/systemd/netif/leases/%s", iface),
+		"/var/lib/dhcp/dhclient.leases",
+	}
+	for _, path := range candidates {
+		data, err := os.ReadFile(path) //nolint:gosec // known lease paths
+		if err != nil {
+			continue
+		}
+		if routes := parseLinuxClasslessRoutes(string(data)); len(routes) > 0 {
+			return routes, nil
+		}
+	}
+	return nil, nil
+}
+
+// parseLinuxClasslessRoutes extracts routes from any of the supported lease
+// formats on Linux. Exposed for tests.
+func parseLinuxClasslessRoutes(lease string) []DHCPRoute {
+	// 1. dhclient hex-encoded form: "8:a:1:1:1, 0:c0:a8:1:1"
+	if routes := parseDhclientHexRoutes(lease); len(routes) > 0 {
+		return routes
+	}
+	// 2. key=value form (dhcpcd/systemd-networkd). Match either the bare
+	//    key name or quoted value.
+	kvRE := regexp.MustCompile(`(?i)(?:new_)?classless_static_routes=['"]?([^'"\n]+)['"]?`)
+	for _, m := range kvRE.FindAllStringSubmatch(lease, -1) {
+		payload := strings.TrimSpace(m[1])
+		fields := strings.Fields(payload)
+		// Expect even count: [cidr1 gw1 cidr2 gw2 ...]
+		if len(fields) < 2 || len(fields)%2 != 0 {
+			continue
+		}
+		var routes []DHCPRoute
+		for i := 0; i+1 < len(fields); i += 2 {
+			routes = append(routes, DHCPRoute{CIDR: fields[i], Gateway: fields[i+1]})
+		}
+		if len(routes) > 0 {
+			return routes
+		}
+	}
+	return nil
+}
+
+// parseDhclientHexRoutes decodes the ISC dhclient line:
+//
+//	option rfc3442-classless-static-routes 8:a:1:1:1, 0:c0:a8:1:1;
+//
+// Each entry is {prefix-length, destination-octets..., gateway-octets-4}.
+// Destination octets are omitted trailing zeros — e.g. "8:a" is "10.0.0.0/8".
+func parseDhclientHexRoutes(lease string) []DHCPRoute {
+	re := regexp.MustCompile(`(?i)option\s+rfc3442-classless-static-routes\s+([^;]+);`)
+	m := re.FindStringSubmatch(lease)
+	if m == nil {
+		return nil
+	}
+	entries := strings.Split(m[1], ",")
+	var routes []DHCPRoute
+	for _, entry := range entries {
+		bytes := strings.Split(strings.TrimSpace(entry), ":")
+		if len(bytes) < 5 {
+			continue
+		}
+		prefix, err := strconv.Atoi(bytes[0])
+		if err != nil || prefix < 0 || prefix > 32 {
+			continue
+		}
+		// destOctets = ceil(prefix/8)
+		destOctets := (prefix + 7) / 8
+		if len(bytes) != 1+destOctets+4 {
+			continue
+		}
+		dest := make([]int, 4)
+		for i := 0; i < destOctets; i++ {
+			v, err := strconv.ParseUint(bytes[1+i], 16, 8)
+			if err != nil {
+				continue
+			}
+			dest[i] = int(v)
+		}
+		gw := make([]int, 4)
+		for i := 0; i < 4; i++ {
+			v, err := strconv.ParseUint(bytes[1+destOctets+i], 16, 8)
+			if err != nil {
+				continue
+			}
+			gw[i] = int(v)
+		}
+		cidr := fmt.Sprintf("%d.%d.%d.%d/%d", dest[0], dest[1], dest[2], dest[3], prefix)
+		gateway := fmt.Sprintf("%d.%d.%d.%d", gw[0], gw[1], gw[2], gw[3])
+		routes = append(routes, DHCPRoute{CIDR: cidr, Gateway: gateway})
+	}
+	return routes
+}
+
+// AddRoute installs an IPv4 route on Linux via `ip route add`. Idempotent.
+func AddRoute(cidr, gateway string) error {
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		return fmt.Errorf("add route: invalid cidr %q: %w", cidr, err)
+	}
+	if net.ParseIP(gateway) == nil {
+		return fmt.Errorf("add route: invalid gateway %q", gateway)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ip", "route", "add", cidr, "via", gateway).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "File exists") || strings.Contains(msg, "already exists") {
+			return nil
+		}
+		return fmt.Errorf("ip route add: %w: %s", err, msg)
+	}
+	return nil
+}
+
+// DeleteRoute removes an IPv4 route previously added via AddRoute. Missing
+// route is not treated as error.
+func DeleteRoute(cidr string) error {
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		return fmt.Errorf("delete route: invalid cidr %q: %w", cidr, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ip", "route", "del", cidr).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "No such process") || strings.Contains(msg, "not found") {
+			return nil
+		}
+		return fmt.Errorf("ip route del: %w: %s", err, msg)
+	}
+	return nil
 }

--- a/go/internal/platform/platform.go
+++ b/go/internal/platform/platform.go
@@ -33,6 +33,23 @@ type ArpEntry struct {
 	Interface string
 }
 
+// DHCPRoute is one entry from DHCP option 121 (RFC 3442 classless static
+// routes). Gateway is the next-hop IP; CIDR is always canonical
+// "network/prefix" (e.g. "10.0.0.0/8" or "0.0.0.0/0" for default route).
+//
+// Option 121 is the delivery channel behind CVE-2024-3661 ("TunnelVision"):
+// a DHCP-advertised route can bypass policy chains that inspect only
+// packets in the default-route path. Wave 21 technique #23 uses this.
+type DHCPRoute struct {
+	CIDR    string
+	Gateway string
+}
+
+// IsDefault reports whether this route represents the IPv4 default route.
+func (r DHCPRoute) IsDefault() bool {
+	return r.CIDR == "0.0.0.0/0" || r.CIDR == "::/0"
+}
+
 // StealthState holds the original system settings for stealth restoration.
 type StealthState struct {
 	OriginalTTL  int

--- a/go/internal/techniques/techniques.go
+++ b/go/internal/techniques/techniques.go
@@ -32,7 +32,7 @@ const (
 	DoQTunnel     ID = "doq_tunnel"             // DNS-over-QUIC tunnel
 	HTTP3Tunnel   ID = "http3_tunnel"           // HTTP/3-specific tunnel (QUIC Alt-Svc)
 	// Wave 21: Serverless, infrastructure-native techniques (2026-04).
-	DHCPRouteBypass ID = "dhcp_route_bypass" // CVE-2024-3661 TunnelVision / DHCP option 121
+	DHCPRouteBypass ID = "dhcp_route_bypass" //nolint:gosec // G101 false positive on "bypass"; not a credential. CVE-2024-3661 TunnelVision.
 )
 
 // BypassTechniqueSignals captures the probe facts needed for feasibility

--- a/go/internal/techniques/techniques.go
+++ b/go/internal/techniques/techniques.go
@@ -31,6 +31,8 @@ const (
 	CAPPORTExtend ID = "capport_session_extend" // RFC 8908 session extension
 	DoQTunnel     ID = "doq_tunnel"             // DNS-over-QUIC tunnel
 	HTTP3Tunnel   ID = "http3_tunnel"           // HTTP/3-specific tunnel (QUIC Alt-Svc)
+	// Wave 21: Serverless, infrastructure-native techniques (2026-04).
+	DHCPRouteBypass ID = "dhcp_route_bypass" // CVE-2024-3661 TunnelVision / DHCP option 121
 )
 
 // BypassTechniqueSignals captures the probe facts needed for feasibility
@@ -60,6 +62,10 @@ type BypassTechniqueSignals struct {
 	// HTTP3Open is true when a test UDP/443 QUIC handshake succeeds
 	// (distinct from QUICOpen which may only check protocol presence).
 	HTTP3Open bool
+	// DHCPClasslessRoutesAvailable is true when the DHCP server advertises
+	// RFC 3442 option 121 routes AND at least one is non-default. Powers
+	// Wave 21 technique #23 (CVE-2024-3661 TunnelVision).
+	DHCPClasslessRoutesAvailable bool
 }
 
 // BypassTechniqueInfo is the canonical user-facing metadata for a bypass
@@ -378,6 +384,26 @@ var bypassTechniqueSpecs = []bypassTechniqueSpec{
 				"Bypasses TCP-only middleboxes and portal filters focused on TCP/443.",
 			Remediation: "Deploy QUIC-aware inspection. Block UDP/443 to untrusted destinations for " +
 				"unauthenticated clients. Inspect Alt-Svc headers for rogue endpoints.",
+		},
+	},
+	// Wave 21 (2026-04): serverless DHCP option 121 route injection.
+	// Based on CVE-2024-3661 ("TunnelVision", Leviathan Security 2024-05).
+	{
+		info: BypassTechniqueInfo{
+			Number: 23, ID: DHCPRouteBypass, Name: "DHCP Option 121 route bypass", HelpName: "DHCP route",
+			Confidence: "MEDIUM", Reason: "DHCP advertises non-default classless static routes",
+			Risk: "Adds kernel routes -- rolls back on failure",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool {
+			return signals.DHCPClasslessRoutesAvailable
+		},
+		success: BypassTechniqueResultMetadata{
+			Severity: "high",
+			Impact: "Full internet via DHCP-advertised routes that bypass portal filtering chains. " +
+				"Same primitive as CVE-2024-3661 applied to captive portals.",
+			Remediation: "Strip DHCP option 121 on untrusted networks. Enforce captive policy in the " +
+				"forwarding plane (netfilter/PF FORWARD chain) rather than only in the default-route " +
+				"chain. Alert on DHCP leases advertising non-default static routes.",
 		},
 	},
 }

--- a/go/internal/techniques/techniques_test.go
+++ b/go/internal/techniques/techniques_test.go
@@ -7,8 +7,8 @@ import "testing"
 
 func TestBypassTechniqueInfosAreOrderedAndUnique(t *testing.T) {
 	infos := BypassTechniqueInfos()
-	if len(infos) != 22 {
-		t.Fatalf("BypassTechniqueInfos() length = %d, want 22", len(infos))
+	if len(infos) != 23 {
+		t.Fatalf("BypassTechniqueInfos() length = %d, want 23", len(infos))
 	}
 
 	seen := make(map[ID]bool, len(infos))
@@ -34,8 +34,8 @@ func TestServerRequirementSplitMatchesCurrentTechniqueContract(t *testing.T) {
 	serverless := ServerlessBypassTechniqueInfos()
 	serverRequired := ServerRequiredBypassTechniqueInfos()
 
-	if len(serverless) != 11 {
-		t.Fatalf("len(ServerlessBypassTechniqueInfos()) = %d, want 11", len(serverless))
+	if len(serverless) != 12 {
+		t.Fatalf("len(ServerlessBypassTechniqueInfos()) = %d, want 12", len(serverless))
 	}
 	if len(serverRequired) != 11 {
 		t.Fatalf("len(ServerRequiredBypassTechniqueInfos()) = %d, want 11", len(serverRequired))


### PR DESCRIPTION
## Summary
First Wave 21 technique from #8. Applies the TunnelVision (CVE-2024-3661) primitive to captive-portal bypass: some portal gateways enforce policy only in the default-route chain, so a DHCP-advertised **non-default** classless static route (RFC 3442 option 121) can establish a second path that bypasses filtering.

**Scope**: we do NOT spoof DHCP. We only honor what the network itself advertised. Narrowest-prefix-first trial to minimize blast radius; rollback on failure so we never leave the user worse off.

## What landed

### Platform layer
- \`platform.DHCPRoute{CIDR, Gateway}\` + \`IsDefault()\`
- \`GetDHCPClasslessRoutes(iface)\` — darwin (\`ipconfig getpacket\`) + linux (dhclient hex, dhcpcd key=value, systemd-networkd, using the canonical lease-file list already used by \`GetCAPPORTURL\`)
- \`AddRoute\` / \`DeleteRoute\` — idempotent, CIDR/IP-validated, native \`route\` / \`ip route\`

### Bypass layer
- Method \`DHCPRouteBypass\` (\`dhcp_route_bypass\`)
- \`Config.DHCPClasslessRoutes\` wired at audit entry
- \`tryDHCPRouteBypass\`: filter non-default → narrowest-first → AddRoute → verify gstatic 204 → success keeps route / failure rolls back
- \`platformAddRoute\` / \`platformDeleteRoute\` indirections for testability

### Techniques registry
Technique **#23**, MEDIUM confidence. Reason: *DHCP advertises non-default classless static routes*. Remediation calls out iptables FORWARD-chain coverage and option-121 stripping. New \`BypassTechniqueSignals.DHCPClasslessRoutesAvailable\` signal.

## Test plan
- [x] \`go build ./...\` clean (darwin + \`GOOS=linux\` cross-compile)
- [x] \`go vet ./...\` clean
- [x] New tests: dhclient hex form (incl. RFC 3442 \"prefix=8 dest=10\" truncated octets), dhcpcd, systemd-networkd; runner covers no-routes / only-default / happy path / rollback-on-500 / narrowest-first / input sanitation
- [x] Full suite: 22/22 packages pass (bypass 9s, platform 0.3s)
- [ ] CI to confirm lint/race/govulncheck

## Counts
Bypass 19→22→**23**, total 27→30→**31**. README + help strings + test expectations updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)