### PR TITLE
feat(ech): auto-discover ECHConfigList via DoH

### DIFF
--- a/go/internal/bypass/bypass_ech.go
+++ b/go/internal/bypass/bypass_ech.go
@@ -4,7 +4,9 @@
 package bypass
 
 import (
+	"encoding/base64"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/MikkoParkkola/nowifi/internal/tunnel"
@@ -31,17 +33,34 @@ func tryECHFronting(config *Config, _ *ProbeResults) Result {
 			Details: "ECH technique requires --ech-server and --ech-config-list.",
 		}
 	}
-	if config.ECHServerURL == "" || config.ECHConfigListBase64 == "" {
+	if config.ECHServerURL == "" {
 		return Result{
 			Method:  ECHFronting,
 			Success: false,
-			Details: "ECH not configured. Provide --ech-server <https-url> and --ech-config-list <base64>.",
+			Details: "ECH not configured. Provide --ech-server <https-url>.",
+		}
+	}
+
+	// Auto-discover ECHConfigList via DoH if not manually provided.
+	echConfigB64 := config.ECHConfigListBase64
+	if echConfigB64 == "" {
+		if u, err := url.Parse(config.ECHServerURL); err == nil && u.Hostname() != "" {
+			if discovered, err := tunnel.DiscoverECHConfigList(u.Hostname()); err == nil && len(discovered) > 0 {
+				echConfigB64 = base64.StdEncoding.EncodeToString(discovered)
+			}
+		}
+	}
+	if echConfigB64 == "" {
+		return Result{
+			Method:  ECHFronting,
+			Success: false,
+			Details: "ECH config not found via DoH auto-discovery. Provide --ech-config-list <base64> manually.",
 		}
 	}
 
 	handle, err := tunnel.StartECHProxy(tunnel.ECHServerConfig{
 		ServerURL:           config.ECHServerURL,
-		ECHConfigListBase64: config.ECHConfigListBase64,
+		ECHConfigListBase64: echConfigB64,
 		Timeout:             15 * time.Second,
 	}, 0)
 	if err != nil {

--- a/go/internal/tunnel/ech_discovery.go
+++ b/go/internal/tunnel/ech_discovery.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package tunnel
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DiscoverECHConfigList fetches the ECHConfigList for a hostname by querying
+// its HTTPS DNS RR (type 65) via DNS-over-HTTPS. Returns the raw bytes
+// (ready for tls.Config.EncryptedClientHelloConfigList) or an error.
+//
+// Tries Cloudflare (1.1.1.1) first, then Google (8.8.8.8). These DoH
+// endpoints are commonly whitelisted by captive portals since they're needed
+// for legitimate HTTPS browsing.
+func DiscoverECHConfigList(hostname string) ([]byte, error) {
+	if hostname == "" {
+		return nil, errors.New("ech discovery: empty hostname")
+	}
+
+	providers := []struct {
+		name string
+		url  string
+	}{
+		{"Cloudflare", "https://cloudflare-dns.com/dns-query"},
+		{"Google", "https://dns.google/resolve"},
+	}
+
+	var lastErr error
+	for _, p := range providers {
+		raw, err := queryHTTPSRR(p.url, hostname)
+		if err != nil {
+			lastErr = fmt.Errorf("%s: %w", p.name, err)
+			continue
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("ech discovery: all providers failed: %w", lastErr)
+}
+
+// dohResponse is the minimal JSON wire format for DoH application/dns-json.
+type dohResponse struct {
+	Status int         `json:"Status"`
+	Answer []dohAnswer `json:"Answer"`
+}
+
+type dohAnswer struct {
+	Name string `json:"name"`
+	Type int    `json:"type"`
+	Data string `json:"data"`
+}
+
+func queryHTTPSRR(endpoint, hostname string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	url := fmt.Sprintf("%s?name=%s&type=HTTPS", endpoint, hostname)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/dns-json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("DoH request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("DoH HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var doh dohResponse
+	if err := json.Unmarshal(body, &doh); err != nil {
+		return nil, fmt.Errorf("parse JSON: %w", err)
+	}
+
+	if doh.Status != 0 {
+		return nil, fmt.Errorf("DNS error status %d", doh.Status)
+	}
+
+	// Find HTTPS RR (type 65) answers and extract the ech= SvcParam.
+	for _, ans := range doh.Answer {
+		if ans.Type != 65 {
+			continue
+		}
+		echB64 := extractECHFromSvcParams(ans.Data)
+		if echB64 == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(echB64)
+		if err != nil {
+			// Try URL-safe or raw variants.
+			decoded, err = base64.RawStdEncoding.DecodeString(echB64)
+			if err != nil {
+				continue
+			}
+		}
+		if len(decoded) > 0 {
+			return decoded, nil
+		}
+	}
+
+	return nil, errors.New("no ECH config in HTTPS RR")
+}
+
+// extractECHFromSvcParams parses the presentation-format HTTPS RR data
+// and extracts the ech= SvcParam value. The data looks like:
+//
+//	1 . alpn="h2,h3" ech=AAAA... ipv4hint=1.2.3.4
+//
+// or with quoting:
+//
+//	1 . alpn=h2,h3 ech="AAAA..."
+func extractECHFromSvcParams(data string) string {
+	// Split on whitespace and look for ech= parameter.
+	for _, field := range strings.Fields(data) {
+		if strings.HasPrefix(field, "ech=") {
+			val := strings.TrimPrefix(field, "ech=")
+			// Strip surrounding quotes if present.
+			val = strings.Trim(val, "\"")
+			return val
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Auto-fetch ECHConfigList from HTTPS DNS RR (type 65) via DoH when `--ech-config-list` is omitted
- Tries Cloudflare DoH → Google DoH as fallback
- Makes technique #24 zero-config: `sudo nowifi --ech-server https://proxy` just works
- Falls back to manual `--ech-config-list` if auto-discovery fails

## Test plan

- [x] `go build ./...` compiles
- [x] All existing tests pass
- [ ] Field test: verify DoH discovery returns valid ECHConfigList for a Cloudflare-ECH-enabled domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)