### PR TITLE
feat(bypass): Wave 22 #29-#30 — HTTP/2 CONNECT + SSE tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Author: Mikko Parkkola**
 
-One command. 36 techniques. Browser works immediately.
+One command. 38 techniques. Browser works immediately.
 
 ```bash
 sudo nowifi
@@ -23,7 +23,7 @@ sudo nowifi
   <img src="screenshot.png" alt="nowifi dashboard" width="800">
 </p>
 
-Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 28 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
+Stuck behind a hotel/airport/cafe WiFi login page? `nowifi` detects the captive portal, probes for weaknesses, and tries 30 bypass techniques automatically -- most powerful first, stops on the first one that works. Your browser works immediately. `Ctrl+C` restores everything.
 
 Need the actual WiFi password instead? `nowifi crack` runs an ordered 8-technique WPA/WPA2 cracking pipeline. It escalates from PMKID and WPS Pixie-Dust through handshake capture, dictionary/smart cracking, and only then to WPS PIN or online brute force, stopping as soon as a password is recovered.
 
@@ -123,6 +123,8 @@ nowifi doctor
 | `sudo nowifi --ech-server https://... --ech-config-list <b64>` | TLS 1.3 ECH domain fronting (#24) |
 | `sudo nowifi --masque-server https://proxy:443` | MASQUE tunnel via HTTP/3 Extended CONNECT (#27) |
 | `sudo nowifi --wt-server https://proxy:443/wt` | WebTransport tunnel over HTTP/3 (#28) |
+| `sudo nowifi --h2-proxy https://proxy:443` | HTTP/2 CONNECT tunnel (gRPC-style) (#29) |
+| `sudo nowifi --sse-server https://relay.example.com` | SSE streaming tunnel (#30) |
 | `sudo nowifi -i en1` | Use a different WiFi interface (default: `en0`) |
 | `nowifi recon -o klm.json` | Passive network fingerprint for contributing provider profiles |
 | `nowifi diagnose` | Read-only security assessment (no changes to network) |
@@ -149,9 +151,9 @@ nowifi doctor
 
 ---
 
-## 36 Techniques
+## 38 Techniques
 
-### Portal Bypass (28 techniques)
+### Portal Bypass (30 techniques)
 
 These work when you're connected to WiFi but stuck behind a captive portal login page.
 
@@ -185,6 +187,8 @@ These work when you're connected to WiFi but stuck behind a captive portal login
 | 26 | **Secondary interface** | Use cellular/USB-Ethernet/Bluetooth-PAN to exit the carrier, bypassing portal entirely (serverless) | Critical |
 | 27 | **MASQUE tunnel** | HTTP/3 Extended CONNECT (RFC 9220/9298) — identical to Apple Private Relay/Cloudflare WARP | Critical |
 | 28 | **WebTransport tunnel** | RFC 9220 WebTransport over HTTP/3 — looks like Google Meet/Zoom to DPI | Critical |
+| 29 | **HTTP/2 CONNECT tunnel** | HTTP/2 binary-framed CONNECT — looks like gRPC/Cloud API to DPI | Critical |
+| 30 | **SSE streaming tunnel** | Server-Sent Events downlink + HTTP POST uplink — looks like a news feed | High |
 
 ### WPA Cracking (4 techniques)
 
@@ -192,19 +196,19 @@ These crack the actual WiFi password when you don't have it. The stages run in o
 
 | # | Technique | How it works |
 |---|-----------|-------------|
-| 29 | **PMKID capture** | Extract PMKID from AP's first message -- no clients needed (~60% of APs) |
-| 30 | **WPS Pixie-Dust** | Exploit weak RNG in WPS (~30% of WPS-enabled APs, 5-30s) |
-| 31 | **Handshake capture + hashcat** | Deauth a client, capture 4-way handshake, GPU crack |
-| 32 | **WPS PIN brute force** | Brute force 11,000 PIN combinations (2-10 hours, last resort) |
+| 31 | **PMKID capture** | Extract PMKID from AP's first message -- no clients needed (~60% of APs) |
+| 32 | **WPS Pixie-Dust** | Exploit weak RNG in WPS (~30% of WPS-enabled APs, 5-30s) |
+| 33 | **Handshake capture + hashcat** | Deauth a client, capture 4-way handshake, GPU crack |
+| 34 | **WPS PIN brute force** | Brute force 11,000 PIN combinations (2-10 hours, last resort) |
 
 ### Smart Cracking (4 additional strategies)
 
 | # | Technique | How it works |
 |---|-----------|-------------|
-| 33 | **Smart common passwords** | Top 1000 WiFi passwords (embedded, no wordlist needed) |
-| 34 | **Numeric mask attack** | 8-digit patterns common in ISP-issued routers |
-| 35 | **Word+number rules** | Hashcat rules combining dictionary words with numbers |
-| 36 | **Online brute force** | wpa_supplicant PSK attempts (no monitor mode needed) |
+| 35 | **Smart common passwords** | Top 1000 WiFi passwords (embedded, no wordlist needed) |
+| 36 | **Numeric mask attack** | 8-digit patterns common in ISP-issued routers |
+| 37 | **Word+number rules** | Hashcat rules combining dictionary words with numbers |
+| 38 | **Online brute force** | wpa_supplicant PSK attempts (no monitor mode needed) |
 
 The smart-crack pipeline also runs dictionary, smart-brute, and (opt-in) full-brute stages between rules and online brute force, in increasing cost order.
 

--- a/go/internal/bypass/bypass.go
+++ b/go/internal/bypass/bypass.go
@@ -84,6 +84,10 @@ const (
 	MASQUETunnel Method = techniques.MASQUETunnel
 	// Wave 21: WebTransport tunnel (RFC 9220).
 	WebTransportTunnel Method = techniques.WebTransportTunnel
+	// Wave 22: HTTP/2 CONNECT tunnel.
+	H2ConnectTunnel Method = techniques.H2ConnectTunnel
+	// Wave 22: SSE streaming tunnel.
+	SSETunnel Method = techniques.SSETunnel
 )
 
 // Config holds user-specified settings for the bypass engine.
@@ -127,6 +131,10 @@ type Config struct {
 	MASQUEServerURL string
 	// WTServerURL is the WebTransport tunnel endpoint (https://...). Powers #28.
 	WTServerURL string
+	// H2ProxyURL is an HTTP/2 CONNECT-capable proxy (https://...). Powers #29.
+	H2ProxyURL string
+	// SSEServerURL is the SSE relay endpoint (https://...). Powers #30.
+	SSEServerURL string
 }
 
 // Result records the outcome of a single bypass attempt.
@@ -423,6 +431,18 @@ var techniqueRunnerByMethod = map[Method]techniqueRunner{
 	WebTransportTunnel: {
 		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
 			return tryWebTransportTunnel(config, probes)
+		},
+	},
+	// Wave 22: HTTP/2 CONNECT tunnel.
+	H2ConnectTunnel: {
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
+			return tryH2ConnectTunnel(config, probes)
+		},
+	},
+	// Wave 22: SSE streaming tunnel.
+	SSETunnel: {
+		run: func(probes *ProbeResults, config *Config, _ PlatformOps) Result {
+			return trySSETunnel(config, probes)
 		},
 	},
 }

--- a/go/internal/bypass/bypass_h2.go
+++ b/go/internal/bypass/bypass_h2.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package bypass
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/tunnel"
+)
+
+func tryH2ConnectTunnel(config *Config, _ *ProbeResults) Result {
+	if config == nil || config.H2ProxyURL == "" {
+		return Result{
+			Method:  H2ConnectTunnel,
+			Success: false,
+			Details: "No HTTP/2 proxy configured (use --h2-proxy https://...).",
+		}
+	}
+
+	handle, err := tunnel.StartH2ConnectTunnel(config.H2ProxyURL, 0, 15*time.Second)
+	if err != nil {
+		return Result{
+			Method:  H2ConnectTunnel,
+			Success: false,
+			Details: fmt.Sprintf("HTTP/2 CONNECT failed (%s): %v", config.H2ProxyURL, err),
+		}
+	}
+
+	if tunnel.VerifySOCKS(handle.LocalPort) {
+		return successResult(
+			H2ConnectTunnel,
+			fmt.Sprintf("HTTP/2 CONNECT tunnel to %s active. Binary-framed multiplexed "+
+				"streams — looks like gRPC/Cloud API to DPI. SOCKS5 at 127.0.0.1:%d.",
+				config.H2ProxyURL, handle.LocalPort),
+			withTunnel(handle),
+		)
+	}
+
+	handle.Stop()
+	return Result{
+		Method:  H2ConnectTunnel,
+		Success: false,
+		Details: "HTTP/2 CONNECT negotiated but SOCKS verification failed.",
+	}
+}

--- a/go/internal/bypass/bypass_sse.go
+++ b/go/internal/bypass/bypass_sse.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package bypass
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/tunnel"
+)
+
+func trySSETunnel(config *Config, _ *ProbeResults) Result {
+	if config == nil || config.SSEServerURL == "" {
+		return Result{
+			Method:  SSETunnel,
+			Success: false,
+			Details: "No SSE relay configured (use --sse-server https://...).",
+		}
+	}
+
+	handle, err := tunnel.StartSSETunnel(config.SSEServerURL, 0, 15*time.Second)
+	if err != nil {
+		return Result{
+			Method:  SSETunnel,
+			Success: false,
+			Details: fmt.Sprintf("SSE tunnel failed (%s): %v", config.SSEServerURL, err),
+		}
+	}
+
+	if tunnel.VerifySOCKS(handle.LocalPort) {
+		return successResult(
+			SSETunnel,
+			fmt.Sprintf("SSE tunnel to %s active. Downlink is a text/event-stream "+
+				"(looks like a news feed). SOCKS5 at 127.0.0.1:%d.",
+				config.SSEServerURL, handle.LocalPort),
+			withTunnel(handle),
+		)
+	}
+
+	handle.Stop()
+	return Result{
+		Method:  SSETunnel,
+		Success: false,
+		Details: "SSE stream connected but SOCKS verification failed.",
+	}
+}

--- a/go/internal/bypass/bypass_test.go
+++ b/go/internal/bypass/bypass_test.go
@@ -147,6 +147,10 @@ func TestReadmeTechniqueClaimsMatchImplementation(t *testing.T) {
 		MASQUETunnel,
 		// Wave 21: WebTransport tunnel (RFC 9220).
 		WebTransportTunnel,
+		// Wave 22: HTTP/2 CONNECT tunnel.
+		H2ConnectTunnel,
+		// Wave 22: SSE streaming tunnel.
+		SSETunnel,
 	}
 	crackMethods := []crack.Method{
 		crack.PMKID,

--- a/go/internal/cli/audit.go
+++ b/go/internal/cli/audit.go
@@ -254,6 +254,8 @@ func runAuditPipeline(p *tea.Program, startTime time.Time, stealth bool, wifi *p
 		ECHConfigListBase64: flagECHConfigB64,
 		MASQUEServerURL:    flagMASQUEServer,
 		WTServerURL:        flagWTServer,
+		H2ProxyURL:         flagH2Proxy,
+		SSEServerURL:       flagSSEServer,
 		Stealth:            stealth,
 	}
 

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -115,8 +115,8 @@ func TestHelpContainsBypassTechniqueCount(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "28 portal bypass techniques") {
-		t.Errorf("--help output should contain '28 portal bypass techniques', got:\n%s", output)
+	if !strings.Contains(output, "30 portal bypass techniques") {
+		t.Errorf("--help output should contain '30 portal bypass techniques', got:\n%s", output)
 	}
 }
 
@@ -345,10 +345,10 @@ func TestRootLongDescription(t *testing.T) {
 		substr string
 	}{
 		{"mentions sudo", "sudo nowifi"},
-		{"mentions overall technique count", "36 techniques overall"},
+		{"mentions overall technique count", "38 techniques overall"},
 		{"mentions IPv6", "IPv6"},
 		{"mentions DNS tunnel", "DNS tunnel"},
-		{"mentions portal bypass split", "Portal bypass (28): nowifi"},
+		{"mentions portal bypass split", "Portal bypass (30): nowifi"},
 		{"mentions crack split", "WPA cracking (4):   nowifi crack"},
 	}
 

--- a/go/internal/cli/root.go
+++ b/go/internal/cli/root.go
@@ -73,6 +73,8 @@ var (
 	flagWSServer     string
 	flagMASQUEServer string
 	flagWTServer     string
+	flagH2Proxy      string
+	flagSSEServer    string
 	flagECHServer    string
 	flagECHConfigB64 string
 	flagStealth      bool
@@ -98,6 +100,8 @@ func init() {
 	rootCmd.Flags().StringVar(&flagWSServer, "ws-server", "", "WebSocket tunnel server URL (wss://...) (Wave 21 #25)")
 	rootCmd.Flags().StringVar(&flagMASQUEServer, "masque-server", "", "MASQUE proxy URL (https://...) for HTTP/3 Extended CONNECT (Wave 21 #27)")
 	rootCmd.Flags().StringVar(&flagWTServer, "wt-server", "", "WebTransport tunnel server URL (https://...) (Wave 21 #28)")
+	rootCmd.Flags().StringVar(&flagH2Proxy, "h2-proxy", "", "HTTP/2 CONNECT proxy URL (https://...) (Wave 22 #29)")
+	rootCmd.Flags().StringVar(&flagSSEServer, "sse-server", "", "SSE relay server URL (https://...) (Wave 22 #30)")
 	rootCmd.Flags().StringVar(&flagECHServer, "ech-server", "", "HTTPS URL of ECH-capable bypass proxy (Wave 21 #24)")
 	rootCmd.Flags().StringVar(&flagECHConfigB64, "ech-config-list", "", "Base64 ECHConfigList from the server's HTTPS DNS RR")
 	rootCmd.Flags().BoolVar(&flagStealth, "stealth", true, "Randomized probe timing (default)")
@@ -201,6 +205,20 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 	if flagMASQUEServer != "" {
 		if _, err := platform.ValidateURL(flagMASQUEServer); err != nil {
 			return fmt.Errorf("--masque-server: %w", err)
+		}
+	}
+
+	// H2 proxy: must be a valid URL if provided.
+	if flagH2Proxy != "" {
+		if _, err := platform.ValidateURL(flagH2Proxy); err != nil {
+			return fmt.Errorf("--h2-proxy: %w", err)
+		}
+	}
+
+	// SSE server: must be a valid URL if provided.
+	if flagSSEServer != "" {
+		if _, err := platform.ValidateURL(flagSSEServer); err != nil {
+			return fmt.Errorf("--sse-server: %w", err)
 		}
 	}
 

--- a/go/internal/techniques/techniques.go
+++ b/go/internal/techniques/techniques.go
@@ -38,6 +38,9 @@ const (
 	WGOverWebSocket      ID = "wg_over_websocket"
 	MASQUETunnel         ID = "masque_tunnel"         // RFC 9298 CONNECT via HTTP/3 Extended CONNECT
 	WebTransportTunnel   ID = "webtransport_tunnel"   // RFC 9220 WebTransport over HTTP/3
+	// Wave 22: Application-layer smuggling techniques (2026-04).
+	H2ConnectTunnel ID = "h2_connect_tunnel" // HTTP/2 CONNECT via gRPC-style framing
+	SSETunnel       ID = "sse_tunnel"        // Server-Sent Events streaming channel
 )
 
 // BypassTechniqueSignals captures the probe facts needed for feasibility
@@ -84,6 +87,10 @@ type BypassTechniqueSignals struct {
 	MASQUEServerConfigured bool
 	// WTServerConfigured is true when a WebTransport tunnel server URL is set.
 	WTServerConfigured bool
+	// H2ProxyConfigured is true when an HTTP/2 CONNECT proxy URL is set.
+	H2ProxyConfigured bool
+	// SSEServerConfigured is true when an SSE tunnel relay URL is set.
+	SSEServerConfigured bool
 }
 
 // BypassTechniqueInfo is the canonical user-facing metadata for a bypass
@@ -521,6 +528,48 @@ var bypassTechniqueSpecs = []bypassTechniqueSpec{
 				"browser-initiated WebTransport. No commercial DPI distinguishes this from video calls.",
 			Remediation: "Inspect WebTransport session targets. Block CONNECT :protocol webtransport " +
 				"to untrusted destinations for unauthenticated clients. Deploy HTTP/3-aware DPI.",
+		},
+	},
+	// Wave 22 #29: HTTP/2 CONNECT tunnel (gRPC-style binary framing).
+	{
+		info: BypassTechniqueInfo{
+			Number: 29, ID: H2ConnectTunnel, Name: "HTTP/2 CONNECT tunnel", HelpName: "H2 CONNECT",
+			RequiresServer: true, Confidence: "HIGH",
+			Reason: "TCP/443 open + HTTP/2 proxy configured",
+			Risk:   "Requires an HTTP/2 CONNECT-capable proxy",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool {
+			return signals.H2ProxyConfigured && signals.HTTP443Open
+		},
+		success: BypassTechniqueResultMetadata{
+			Severity: "critical",
+			Impact: "Full internet via HTTP/2 CONNECT (RFC 9113). Binary framing is opaque to " +
+				"HTTP/1.1-only DPI. Traffic is indistinguishable from gRPC health checks or " +
+				"Google Cloud API calls. Multiplexed streams share one TLS connection.",
+			Remediation: "Deploy HTTP/2-aware DPI that inspects CONNECT method across multiplexed " +
+				"streams. Block CONNECT to non-whitelisted targets. Most portals only inspect " +
+				"HTTP/1.1 — upgrading to HTTP/2-aware filtering is the primary mitigation.",
+		},
+	},
+	// Wave 22 #30: SSE (Server-Sent Events) streaming covert channel.
+	{
+		info: BypassTechniqueInfo{
+			Number: 30, ID: SSETunnel, Name: "SSE streaming tunnel", HelpName: "SSE tunnel",
+			RequiresServer: true, Confidence: "MEDIUM",
+			Reason: "HTTPS open + SSE relay configured",
+			Risk:   "Asymmetric bandwidth (uplink limited by POST rate)",
+		},
+		feasible: func(signals BypassTechniqueSignals) bool {
+			return signals.SSEServerConfigured && signals.HTTP443Open
+		},
+		success: BypassTechniqueResultMetadata{
+			Severity: "high",
+			Impact: "Internet via SSE downlink + HTTP POST uplink. Downlink is a chunked " +
+				"text/event-stream response indistinguishable from a news feed or chat stream. " +
+				"Uplink uses standard HTTP POST. Serverless CF Workers variant available.",
+			Remediation: "Inspect SSE event payloads for non-text content (base64 data patterns). " +
+				"Rate-limit chunked transfer encoding sessions. Enforce response size limits " +
+				"for unauthenticated clients — note this may break legitimate streaming apps.",
 		},
 	},
 }

--- a/go/internal/techniques/techniques_test.go
+++ b/go/internal/techniques/techniques_test.go
@@ -7,8 +7,8 @@ import "testing"
 
 func TestBypassTechniqueInfosAreOrderedAndUnique(t *testing.T) {
 	infos := BypassTechniqueInfos()
-	if len(infos) != 28 {
-		t.Fatalf("BypassTechniqueInfos() length = %d, want 28", len(infos))
+	if len(infos) != 30 {
+		t.Fatalf("BypassTechniqueInfos() length = %d, want 30", len(infos))
 	}
 
 	seen := make(map[ID]bool, len(infos))
@@ -37,8 +37,8 @@ func TestServerRequirementSplitMatchesCurrentTechniqueContract(t *testing.T) {
 	if len(serverless) != 13 {
 		t.Fatalf("len(ServerlessBypassTechniqueInfos()) = %d, want 13", len(serverless))
 	}
-	if len(serverRequired) != 15 {
-		t.Fatalf("len(ServerRequiredBypassTechniqueInfos()) = %d, want 15", len(serverRequired))
+	if len(serverRequired) != 17 {
+		t.Fatalf("len(ServerRequiredBypassTechniqueInfos()) = %d, want 17", len(serverRequired))
 	}
 
 	foundWhitelist := false
@@ -68,9 +68,11 @@ func TestCountFeasibleBypassTechniquesMatchesCurrentRules(t *testing.T) {
 		HTTP8080Open:           true,
 		MASQUEServerConfigured: true,
 		WTServerConfigured:     true,
+		H2ProxyConfigured:     true,
+		SSEServerConfigured:   true,
 	}
-	if got := CountFeasibleBypassTechniques(allOpen); got != 21 {
-		t.Fatalf("CountFeasibleBypassTechniques(allOpen) = %d, want 21", got)
+	if got := CountFeasibleBypassTechniques(allOpen); got != 23 {
+		t.Fatalf("CountFeasibleBypassTechniques(allOpen) = %d, want 23", got)
 	}
 
 	captiveOnly := BypassTechniqueSignals{PortalDetected: true}

--- a/go/internal/tunnel/h2_connect.go
+++ b/go/internal/tunnel/h2_connect.go
@@ -1,0 +1,266 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package tunnel
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ----------------------------------------------------------------------------
+// Wave 22 technique #29 — HTTP/2 CONNECT tunnel.
+//
+// Opens a TLS/443 connection negotiating HTTP/2 via ALPN "h2", then sends
+// HTTP/2 CONNECT requests to the proxy for each SOCKS5 connection. The
+// traffic is indistinguishable from gRPC health checks, Google Cloud API
+// calls, or any HTTP/2-capable application traffic.
+//
+// Key bypass properties:
+//   - HTTP/2 binary framing is opaque to middleboxes that only inspect
+//     HTTP/1.1 headers. Most captive portal DPI parses only HTTP/1.1.
+//   - The CONNECT method over HTTP/2 multiplexes streams, so all tunnel
+//     traffic shares a single TLS connection with normal HTTP/2 framing.
+//   - gRPC uses exactly this transport (content-type: application/grpc),
+//     making traffic indistinguishable from legitimate cloud API calls.
+//
+// Protocol:
+//   Client → TLS dial to proxy:443 (ALPN "h2")
+//   Verify NegotiatedProtocol == "h2"
+//   Per SOCKS connection:
+//     Client → HTTP/2 CONNECT to target_host:port
+//     Client ← HTTP 200
+//     Client ↔ bidirectional data on the stream
+//
+// This file implements the client side only.
+// ----------------------------------------------------------------------------
+
+// StartH2ConnectTunnel opens an HTTP/2 connection to the proxy and starts a
+// local SOCKS5-lite TCP listener. Each SOCKS connection sends an HTTP/2
+// CONNECT to the target through the proxy.
+func StartH2ConnectTunnel(serverURL string, localPort int, timeout time.Duration) (*Handle, error) {
+	if serverURL == "" {
+		return nil, errors.New("h2 tunnel: serverURL required")
+	}
+	if localPort == 0 {
+		localPort = 1090
+	}
+	if timeout == 0 {
+		timeout = 15 * time.Second
+	}
+
+	addr, sni, err := parseH2Endpoint(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("h2 tunnel: %w", err)
+	}
+
+	// Probe: verify HTTP/2 is negotiated.
+	tlsConf := &tls.Config{
+		ServerName: sni,
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS12,
+	}
+	if clientInsecureTLSForTest {
+		tlsConf.InsecureSkipVerify = true //nolint:gosec // test-only
+	}
+
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), timeout)
+	defer probeCancel()
+	probeConn, err := (&tls.Dialer{}).DialContext(probeCtx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("h2 tunnel: TLS dial %s: %w", addr, err)
+	}
+	tlsConn, ok := probeConn.(*tls.Conn)
+	if !ok || tlsConn.ConnectionState().NegotiatedProtocol != "h2" {
+		_ = probeConn.Close()
+		return nil, fmt.Errorf("h2 tunnel: server did not negotiate h2 (got %q)", tlsConn.ConnectionState().NegotiatedProtocol)
+	}
+	_ = probeConn.Close()
+
+	// Create HTTP/2 transport to the proxy.
+	h2Transport := &http.Transport{
+		TLSClientConfig: tlsConf,
+		ForceAttemptHTTP2: true,
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
+	if err != nil {
+		return nil, fmt.Errorf("h2 tunnel: listen %d: %w", localPort, err)
+	}
+
+	h := &Handle{
+		LocalPort: localPort,
+		Method:    "h2_connect_tunnel",
+		Active:    true,
+		stop:      make(chan struct{}),
+		wg:        &sync.WaitGroup{},
+	}
+	h.wg.Add(1)
+	go serveH2Forwarder(listener, h2Transport, fmt.Sprintf("https://%s", addr), h.stop, h.wg)
+
+	h.extraStop = func() {
+		_ = listener.Close()
+		h2Transport.CloseIdleConnections()
+	}
+	return h, nil
+}
+
+func parseH2Endpoint(s string) (addr, sni string, err error) {
+	switch {
+	case len(s) > 8 && s[:8] == "https://":
+		s = s[8:]
+	case len(s) > 7 && s[:7] == "http://":
+		return "", "", errors.New("HTTP/2 CONNECT requires TLS (use https://)")
+	}
+	// Strip path.
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			s = s[:i]
+			break
+		}
+	}
+	host := s
+	if _, _, splitErr := net.SplitHostPort(host); splitErr != nil {
+		host += ":443"
+	}
+	sniHost, _, _ := net.SplitHostPort(host)
+	if sniHost == "" {
+		return "", "", errors.New("empty host in H2 URL")
+	}
+	return host, sniHost, nil
+}
+
+func serveH2Forwarder(l net.Listener, transport *http.Transport, proxyBase string, stop chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		if tl, ok := l.(*net.TCPListener); ok {
+			_ = tl.SetDeadline(time.Now().Add(1 * time.Second))
+		}
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			continue
+		}
+		go handleH2Socks(conn, transport, proxyBase)
+	}
+}
+
+// handleH2Socks processes a SOCKS5 connection by sending an HTTP/2 CONNECT
+// request to the proxy for the requested target.
+func handleH2Socks(client net.Conn, transport *http.Transport, proxyBase string) {
+	defer func() { _ = client.Close() }()
+	_ = client.SetDeadline(time.Now().Add(30 * time.Second))
+
+	// SOCKS5 greeting.
+	greet := make([]byte, 257)
+	if _, err := io.ReadAtLeast(client, greet[:2], 2); err != nil {
+		return
+	}
+	if greet[0] != 0x05 {
+		return
+	}
+	nmethods := int(greet[1])
+	if nmethods > 0 {
+		if _, err := io.ReadFull(client, greet[:nmethods]); err != nil {
+			return
+		}
+	}
+	if _, err := client.Write([]byte{0x05, 0x00}); err != nil {
+		return
+	}
+
+	// SOCKS5 CONNECT request.
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(client, hdr); err != nil {
+		return
+	}
+	if hdr[1] != 0x01 {
+		_, _ = client.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	var host string
+	switch hdr[3] {
+	case 0x01:
+		ip := make([]byte, 4)
+		if _, err := io.ReadFull(client, ip); err != nil {
+			return
+		}
+		host = net.IP(ip).String()
+	case 0x03:
+		length := make([]byte, 1)
+		if _, err := io.ReadFull(client, length); err != nil {
+			return
+		}
+		name := make([]byte, int(length[0]))
+		if _, err := io.ReadFull(client, name); err != nil {
+			return
+		}
+		host = string(name)
+	default:
+		_, _ = client.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	portBuf := make([]byte, 2)
+	if _, err := io.ReadFull(client, portBuf); err != nil {
+		return
+	}
+	port := binary.BigEndian.Uint16(portBuf)
+	target := fmt.Sprintf("%s:%d", host, port)
+
+	// Send HTTP/2 CONNECT to the proxy.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodConnect, proxyBase, pr)
+	req.Host = target
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		_ = pw.Close()
+		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		_ = pw.Close()
+		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+
+	// SOCKS5 success.
+	if _, err := client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		_ = resp.Body.Close()
+		_ = pw.Close()
+		return
+	}
+	_ = client.SetDeadline(time.Time{})
+
+	// Bidirectional: client→pw→proxy (via request body) and proxy→client (via response body).
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(pw, client); _ = pw.Close(); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(client, resp.Body); _ = resp.Body.Close(); done <- struct{}{} }()
+	<-done
+}
+
+// Ensure bufio import is used (for potential future use in HTTP/1.1 fallback).
+var _ = bufio.NewReader

--- a/go/internal/tunnel/sse_tunnel.go
+++ b/go/internal/tunnel/sse_tunnel.go
@@ -1,0 +1,299 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package tunnel
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ----------------------------------------------------------------------------
+// Wave 22 technique #30 — SSE (Server-Sent Events) streaming tunnel.
+//
+// Uses Server-Sent Events (text/event-stream, RFC 8895 / W3C EventSource)
+// as a covert downlink channel and HTTP POST requests as the uplink. From
+// DPI's perspective, the downlink is an infinite chunked HTTP response
+// identical to a news ticker, stock feed, or chat notification stream.
+// The uplink is a series of ordinary HTTP POST requests.
+//
+// Key bypass properties:
+//   - SSE is standard HTTP/1.1 or HTTP/2 �� no exotic protocols.
+//   - Every major captive portal allows chunked transfer encoding because
+//     blocking it would break all streaming web applications.
+//   - Data is base64-encoded in the `data:` field of SSE events, matching
+//     the byte distribution of real event payloads.
+//   - The Cloudflare Workers variant is serverless: the worker relays SSE
+//     events to/from a target, requiring only a free CF account.
+//
+// Architecture:
+//   Downlink: GET /stream → text/event-stream → data: <base64>\n\n
+//   Uplink:   POST /send   → body: <base64>
+//   Per SOCKS connection: target header in first SSE event, then data flow.
+//
+// This file implements the client side only.
+// ----------------------------------------------------------------------------
+
+// StartSSETunnel opens an SSE streaming connection to the relay server and
+// starts a local SOCKS5-lite TCP listener. Each SOCKS connection gets a
+// dedicated SSE stream (downlink) and POST channel (uplink).
+func StartSSETunnel(serverURL string, localPort int, timeout time.Duration) (*Handle, error) {
+	if serverURL == "" {
+		return nil, errors.New("sse tunnel: serverURL required")
+	}
+	if localPort == 0 {
+		localPort = 1091
+	}
+	if timeout == 0 {
+		timeout = 15 * time.Second
+	}
+
+	// Normalize URL.
+	baseURL := strings.TrimRight(serverURL, "/")
+
+	// Probe: verify SSE endpoint responds with event-stream content type.
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), timeout)
+	defer probeCancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, "GET", baseURL+"/stream?probe=1", nil)
+	if err != nil {
+		return nil, fmt.Errorf("sse tunnel: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sse tunnel: probe %s: %w", baseURL, err)
+	}
+	_ = resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if resp.StatusCode != http.StatusOK || !strings.Contains(ct, "text/event-stream") {
+		return nil, fmt.Errorf("sse tunnel: probe got HTTP %d content-type %q (want text/event-stream)", resp.StatusCode, ct)
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
+	if err != nil {
+		return nil, fmt.Errorf("sse tunnel: listen %d: %w", localPort, err)
+	}
+
+	h := &Handle{
+		LocalPort: localPort,
+		Method:    "sse_tunnel",
+		Active:    true,
+		stop:      make(chan struct{}),
+		wg:        &sync.WaitGroup{},
+	}
+	h.wg.Add(1)
+	go serveSSEForwarder(listener, baseURL, h.stop, h.wg)
+
+	h.extraStop = func() {
+		_ = listener.Close()
+	}
+	return h, nil
+}
+
+func serveSSEForwarder(l net.Listener, baseURL string, stop chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		if tl, ok := l.(*net.TCPListener); ok {
+			_ = tl.SetDeadline(time.Now().Add(1 * time.Second))
+		}
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			continue
+		}
+		go handleSSESocks(conn, baseURL)
+	}
+}
+
+func handleSSESocks(client net.Conn, baseURL string) {
+	defer func() { _ = client.Close() }()
+	_ = client.SetDeadline(time.Now().Add(30 * time.Second))
+
+	// SOCKS5 greeting.
+	greet := make([]byte, 257)
+	if _, err := io.ReadAtLeast(client, greet[:2], 2); err != nil {
+		return
+	}
+	if greet[0] != 0x05 {
+		return
+	}
+	nmethods := int(greet[1])
+	if nmethods > 0 {
+		if _, err := io.ReadFull(client, greet[:nmethods]); err != nil {
+			return
+		}
+	}
+	if _, err := client.Write([]byte{0x05, 0x00}); err != nil {
+		return
+	}
+
+	// SOCKS5 CONNECT.
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(client, hdr); err != nil {
+		return
+	}
+	if hdr[1] != 0x01 {
+		_, _ = client.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	var host string
+	switch hdr[3] {
+	case 0x01:
+		ip := make([]byte, 4)
+		if _, err := io.ReadFull(client, ip); err != nil {
+			return
+		}
+		host = net.IP(ip).String()
+	case 0x03:
+		length := make([]byte, 1)
+		if _, err := io.ReadFull(client, length); err != nil {
+			return
+		}
+		name := make([]byte, int(length[0]))
+		if _, err := io.ReadFull(client, name); err != nil {
+			return
+		}
+		host = string(name)
+	default:
+		_, _ = client.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	portBuf := make([]byte, 2)
+	if _, err := io.ReadFull(client, portBuf); err != nil {
+		return
+	}
+	port := (int(portBuf[0]) << 8) | int(portBuf[1])
+	target := fmt.Sprintf("%s:%d", host, port)
+
+	// Open SSE downlink stream with target in query parameter.
+	streamURL := fmt.Sprintf("%s/stream?target=%s", baseURL, target)
+	req, err := http.NewRequest("GET", streamURL, nil)
+	if err != nil {
+		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+
+	// Extract session ID from response header for uplink correlation.
+	sessionID := resp.Header.Get("X-Session-Id")
+	if sessionID == "" {
+		// Fallback: use target as session key.
+		sessionID = target
+	}
+
+	// SOCKS5 success.
+	if _, err := client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		_ = resp.Body.Close()
+		return
+	}
+	_ = client.SetDeadline(time.Time{})
+
+	done := make(chan struct{}, 2)
+
+	// Downlink: SSE events → base64 decode → client.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		sseReadLoop(resp.Body, client)
+	}()
+
+	// Uplink: client → base64 encode → HTTP POST.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		sseWriteLoop(client, baseURL, sessionID)
+	}()
+
+	<-done
+	_ = resp.Body.Close()
+}
+
+// sseReadLoop reads SSE events from the stream body, decodes the base64
+// data field, and writes raw bytes to the client.
+func sseReadLoop(body io.Reader, client net.Conn) {
+	buf := make([]byte, 8192)
+	var line strings.Builder
+
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			line.Write(buf[:n])
+			// Process complete lines.
+			for {
+				text := line.String()
+				idx := strings.Index(text, "\n")
+				if idx < 0 {
+					break
+				}
+				l := strings.TrimRight(text[:idx], "\r")
+				line.Reset()
+				line.WriteString(text[idx+1:])
+
+				if strings.HasPrefix(l, "data: ") {
+					payload := strings.TrimPrefix(l, "data: ")
+					decoded, decErr := base64.StdEncoding.DecodeString(payload)
+					if decErr == nil && len(decoded) > 0 {
+						if _, wErr := client.Write(decoded); wErr != nil {
+							return
+						}
+					}
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// sseWriteLoop reads from the client, base64-encodes chunks, and POSTs
+// them to the relay server's uplink endpoint.
+func sseWriteLoop(client net.Conn, baseURL, sessionID string) {
+	buf := make([]byte, 4096)
+	sendURL := fmt.Sprintf("%s/send?session=%s", baseURL, sessionID)
+
+	for {
+		n, err := client.Read(buf)
+		if n > 0 {
+			encoded := base64.StdEncoding.EncodeToString(buf[:n])
+			postReq, _ := http.NewRequest("POST", sendURL, strings.NewReader(encoded))
+			postReq.Header.Set("Content-Type", "text/plain")
+			resp, postErr := http.DefaultClient.Do(postReq)
+			if postErr != nil {
+				return
+			}
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#29 HTTP/2 CONNECT tunnel**: Binary-framed multiplexed CONNECT over h2 ALPN. Looks like gRPC/Cloud API. CLI: `--h2-proxy`
- **#30 SSE streaming tunnel**: Server-Sent Events downlink + HTTP POST uplink. Looks like a news feed. CLI: `--sse-server`
- Bypass count: 28 → 30. Total: 36 → 38

## Test plan

- [x] `go build ./...` compiles
- [x] All technique/CLI/bypass tests pass
- [x] `nowifi --help` shows 30 bypass, 38 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)