### PR TITLE
refactor(tunnel): complete SOCKS5 helper migration

### DIFF
--- a/go/internal/tunnel/ech.go
+++ b/go/internal/tunnel/ech.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -219,66 +218,17 @@ func serveECHForwarder(l net.Listener, tlsConf *tls.Config, serverAddr string, s
 	}
 }
 
-// handleECHSocks mirrors handleSocks5Lite but uses an HTTPS CONNECT request
-// over an ECH-cloaked TLS connection for the upstream path.
+// handleECHSocks uses an HTTPS CONNECT request over an ECH-cloaked TLS
+// connection for the upstream path.
 func handleECHSocks(client net.Conn, tlsConf *tls.Config, serverAddr string) {
 	defer func() { _ = client.Close() }()
 	_ = client.SetDeadline(time.Now().Add(30 * time.Second))
 
-	// Minimum SOCKS5 greeting + auth-none reply.
-	greet := make([]byte, 257)
-	if _, err := io.ReadAtLeast(client, greet[:2], 2); err != nil {
+	// SOCKS5 handshake — shared helper parses greeting + CONNECT request.
+	target, err := socks5Handshake(client)
+	if err != nil {
 		return
 	}
-	if greet[0] != 0x05 {
-		return
-	}
-	nmethods := int(greet[1])
-	if nmethods > 0 {
-		if _, err := io.ReadFull(client, greet[:nmethods]); err != nil {
-			return
-		}
-	}
-	if _, err := client.Write([]byte{0x05, 0x00}); err != nil {
-		return
-	}
-
-	hdr := make([]byte, 4)
-	if _, err := io.ReadFull(client, hdr); err != nil {
-		return
-	}
-	if hdr[1] != 0x01 {
-		_, _ = client.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
-		return
-	}
-	var host string
-	switch hdr[3] {
-	case 0x01:
-		ip := make([]byte, 4)
-		if _, err := io.ReadFull(client, ip); err != nil {
-			return
-		}
-		host = net.IP(ip).String()
-	case 0x03:
-		length := make([]byte, 1)
-		if _, err := io.ReadFull(client, length); err != nil {
-			return
-		}
-		name := make([]byte, int(length[0]))
-		if _, err := io.ReadFull(client, name); err != nil {
-			return
-		}
-		host = string(name)
-	default:
-		_, _ = client.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
-		return
-	}
-	portBuf := make([]byte, 2)
-	if _, err := io.ReadFull(client, portBuf); err != nil {
-		return
-	}
-	port := binary.BigEndian.Uint16(portBuf)
-	target := fmt.Sprintf("%s:%d", host, port)
 
 	// Dial upstream with TLS+ECH.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -286,37 +236,37 @@ func handleECHSocks(client net.Conn, tlsConf *tls.Config, serverAddr string) {
 	d := &tls.Dialer{Config: tlsConf}
 	up, err := d.DialContext(ctx, "tcp", serverAddr)
 	if err != nil {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 	defer func() { _ = up.Close() }()
 
 	// Refuse to proceed if ECH didn't actually negotiate on this connection.
 	if !up.(*tls.Conn).ConnectionState().ECHAccepted {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 
 	// HTTPS CONNECT to the upstream proxy; the proxy bridges to `target`.
 	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Connection: keep-alive\r\n\r\n", target, target)
 	if _, err := up.Write([]byte(connectReq)); err != nil {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 
 	// Read the status line; accept any 2xx.
 	if !readHTTP2xxStatus(up) {
-		_, _ = client.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 	// Drain remaining response headers.
 	if err := drainHTTPHeaders(up); err != nil {
-		_, _ = client.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 
-	// Success.
-	if _, err := client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+	// SOCKS5 success.
+	if err := socks5SendSuccess(client); err != nil {
 		return
 	}
 	_ = client.SetDeadline(time.Time{})

--- a/go/internal/tunnel/websocket.go
+++ b/go/internal/tunnel/websocket.go
@@ -231,66 +231,16 @@ func handleWSSocks(client net.Conn, wsAddr, wsPath string, useTLS bool) {
 	defer func() { _ = client.Close() }()
 	_ = client.SetDeadline(time.Now().Add(30 * time.Second))
 
-	// SOCKS5 greeting.
-	greet := make([]byte, 257)
-	if _, err := io.ReadAtLeast(client, greet[:2], 2); err != nil {
+	// SOCKS5 handshake — shared helper parses greeting + CONNECT request.
+	target, err := socks5Handshake(client)
+	if err != nil {
 		return
 	}
-	if greet[0] != 0x05 {
-		return
-	}
-	nmethods := int(greet[1])
-	if nmethods > 0 {
-		if _, err := io.ReadFull(client, greet[:nmethods]); err != nil {
-			return
-		}
-	}
-	if _, err := client.Write([]byte{0x05, 0x00}); err != nil {
-		return
-	}
-
-	// SOCKS5 CONNECT request.
-	hdr := make([]byte, 4)
-	if _, err := io.ReadFull(client, hdr); err != nil {
-		return
-	}
-	if hdr[1] != 0x01 {
-		_, _ = client.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
-		return
-	}
-	var host string
-	switch hdr[3] {
-	case 0x01:
-		ip := make([]byte, 4)
-		if _, err := io.ReadFull(client, ip); err != nil {
-			return
-		}
-		host = net.IP(ip).String()
-	case 0x03:
-		length := make([]byte, 1)
-		if _, err := io.ReadFull(client, length); err != nil {
-			return
-		}
-		name := make([]byte, int(length[0]))
-		if _, err := io.ReadFull(client, name); err != nil {
-			return
-		}
-		host = string(name)
-	default:
-		_, _ = client.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
-		return
-	}
-	portBuf := make([]byte, 2)
-	if _, err := io.ReadFull(client, portBuf); err != nil {
-		return
-	}
-	port := binary.BigEndian.Uint16(portBuf)
-	target := fmt.Sprintf("%s:%d", host, port)
 
 	// Open a fresh WebSocket connection for this tunnel session.
 	ws, err := dialWebSocket(wsAddr, wsPath, useTLS, 15*time.Second)
 	if err != nil {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 	defer func() { _ = ws.Close() }()
@@ -298,22 +248,22 @@ func handleWSSocks(client net.Conn, wsAddr, wsPath string, useTLS bool) {
 	// Send target header: uint16 length + "host:port".
 	targetBytes := []byte(target)
 	if len(targetBytes) > 512 { //nolint:gosec // bounded
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 	lenBuf := make([]byte, 2)
 	binary.BigEndian.PutUint16(lenBuf, uint16(len(targetBytes))) //nolint:gosec // bounded to 512
 	if _, err := ws.Write(lenBuf); err != nil {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 	if _, err := ws.Write(targetBytes); err != nil {
-		_, _ = client.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		socks5SendFail(client)
 		return
 	}
 
-	// SOCKS success.
-	if _, err := client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+	// SOCKS5 success.
+	if err := socks5SendSuccess(client); err != nil {
 		return
 	}
 	_ = client.SetDeadline(time.Time{})


### PR DESCRIPTION
## Summary

- Migrate last 2 tunnel clients (websocket.go, ech.go) to shared `socks5Handshake()` helper
- All 7 tunnel clients now use the same SOCKS5 code path
- Eliminates ~100 more lines of inline SOCKS5 duplication
- Replaces inline byte slices with `socks5SendFail()`/`socks5SendSuccess()` calls

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/tunnel/ ./internal/bypass/` pass
- [x] Zero `SOCKS5 greeting` occurrences outside socks5.go/tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)