### PR TITLE
feat(forensics): nowifi forensics subcommand — offline diagnostic package capture

### DIFF
--- a/go/internal/cli/audit.go
+++ b/go/internal/cli/audit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MikkoParkkola/nowifi/internal/bypass"
 	"github.com/MikkoParkkola/nowifi/internal/capture"
 	"github.com/MikkoParkkola/nowifi/internal/detect"
+	"github.com/MikkoParkkola/nowifi/internal/forensics"
 	"github.com/MikkoParkkola/nowifi/internal/guard"
 	"github.com/MikkoParkkola/nowifi/internal/platform"
 	"github.com/MikkoParkkola/nowifi/internal/probe"
@@ -481,6 +482,7 @@ func maintainSessionTUI(p *tea.Program, iface string, results []bypass.Result, b
 				}
 				if !reconnected {
 					p.Send(bypassResultMsg{technique: "Full bypass", success: false, detail: "all techniques failed"})
+					emitForensicsOnExhaustion(p, iface, stealth, probes)
 				}
 			}
 
@@ -512,6 +514,7 @@ func maintainSessionTUI(p *tea.Program, iface string, results []bypass.Result, b
 				}
 				if !reconnected {
 					p.Send(bypassResultMsg{technique: "Re-probe + bypass", success: false, detail: "all failed"})
+					emitForensicsOnExhaustion(p, iface, stealth, newProbes)
 				}
 			}
 
@@ -524,6 +527,30 @@ func maintainSessionTUI(p *tea.Program, iface string, results []bypass.Result, b
 			}
 		}
 	}
+}
+
+// emitForensicsOnExhaustion is the auto-trigger: when a full bypass exhausts
+// with zero success, it captures a forensic package so the unsolved
+// environment can be analyzed offline. Best-effort and non-fatal — it never
+// panics the audit flow. It runs in its own goroutine so the session-maintain
+// loop is never blocked for the duration of the capture (up to the time cap),
+// and reuses the probes already in scope (no fresh sweep).
+func emitForensicsOnExhaustion(p *tea.Program, iface string, stealth bool, probes *probe.ProbeResults) {
+	go func() {
+		defer func() { _ = recover() }()
+
+		pkg := forensics.Collect(forensics.Options{
+			Iface:   iface,
+			Stealth: stealth,
+		}.WithProbes(probes))
+
+		res, err := pkg.Write("", forensics.WriteOptions{Format: "both"})
+		if err != nil {
+			p.Send(statusMsg{text: fmt.Sprintf("Forensic capture failed: %v", err)})
+			return
+		}
+		p.Send(statusMsg{text: fmt.Sprintf("Bypass exhausted — forensic package saved: %s", res.JSONPath)})
+	}()
 }
 
 func runAuditDryRun(startTime time.Time, stealth bool) {

--- a/go/internal/cli/forensics.go
+++ b/go/internal/cli/forensics.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/forensics"
+	"github.com/spf13/cobra"
+)
+
+var (
+	forensicsOutput       string
+	forensicsFormat       string
+	forensicsBaseline     bool
+	forensicsBaselineFile string
+	forensicsTimeout      int
+	forensicsPortalBase   string
+)
+
+var forensicsCmd = &cobra.Command{
+	Use:   "forensics",
+	Short: "Capture a portable, read-only diagnostic package (offline analysis)",
+	Long: `Capture a portable forensic package of which egress channels survive
+captive-portal enforcement, so an unsolved environment can be analyzed
+later to build a working bypass.
+
+This is a Go port of forensics/captive-forensics.sh (sections 1-10 plus the
+pax-api enforcement control-plane sweep). It is collection-only:
+
+  - READ-ONLY: no MAC changes, no tunnels, no proxy, no network mutation.
+  - NO SUDO: runs without root; privilege-gated probes degrade gracefully and
+    the limitation is recorded in the package.
+  - LOCAL-ONLY: writes to disk and prints the saved paths. Never uploads,
+    never phones home.
+
+Output: two sibling files in the current directory (or --output dir),
+holes-<UTC-timestamp>.txt (human) and holes-<UTC-timestamp>.json (machine).
+
+Baseline diff (section 10): run with --baseline at full access to write a
+baseline file, then later run with --baseline-file <path> under enforcement —
+channels open in BOTH runs are the reliable holes.`,
+	Run: runForensics,
+}
+
+func init() {
+	forensicsCmd.Flags().StringVarP(&forensicsOutput, "output", "o", "",
+		"Output directory for the package (default: current directory)")
+	forensicsCmd.Flags().StringVarP(&forensicsFormat, "format", "f", "both",
+		"Output format: both, json, txt")
+	forensicsCmd.Flags().BoolVar(&forensicsBaseline, "baseline", false,
+		"Capture-at-full-access mode: also write a baseline-<ts>.txt for later diff")
+	forensicsCmd.Flags().StringVar(&forensicsBaselineFile, "baseline-file", "",
+		"Path to a prior baseline file; include a section-10 diff (open in both = reliable holes)")
+	forensicsCmd.Flags().IntVar(&forensicsTimeout, "timeout", 90,
+		"Hard total time cap in seconds for live collection")
+	forensicsCmd.Flags().StringVar(&forensicsPortalBase, "portal-base", "",
+		"Override the pax-api base URL (derived from detected portal otherwise)")
+}
+
+func runForensics(cmd *cobra.Command, args []string) {
+	printBanner("Forensics Mode (read-only, local-only)")
+
+	iface := flagInterface
+	fmt.Printf("  Interface: %s\n", iface)
+
+	// Forensics defaults to the fast path so the total time cap is a backstop,
+	// not the common case (stealth sweeps self-sleep and can approach the cap).
+	stealth := false
+	if cmd.Flags().Changed("stealth") {
+		stealth = flagStealth && !flagFast
+	}
+
+	fmt.Print("  Capturing forensic package (read-only)... ")
+	pkg := forensics.Collect(forensics.Options{
+		Iface:        iface,
+		Stealth:      stealth,
+		PortalBase:   forensicsPortalBase,
+		TotalTimeout: time.Duration(forensicsTimeout) * time.Second,
+	})
+	fmt.Println("done")
+
+	fmt.Printf("  Provider: %s | Gateway: %s\n", pkg.Provider, pkg.GW)
+	fmt.Printf("  Holes found: %d\n", len(pkg.Holes))
+
+	// Optional section-10 baseline diff.
+	if forensicsBaselineFile != "" {
+		baseHoles, err := forensics.ReadBaselineFile(forensicsBaselineFile)
+		if err != nil {
+			fmt.Printf("  (baseline diff skipped: %v)\n", err)
+		} else {
+			reliable := forensics.DiffBaseline(pkg.Holes, baseHoles)
+			fmt.Printf("  Reliable holes (open in both runs): %d\n", len(reliable))
+			for _, h := range reliable {
+				fmt.Printf("    [%s] %s\n", h.Severity, h.Technique)
+			}
+		}
+	}
+
+	res, err := writeForensicsPackage(pkg)
+	if err != nil {
+		fmt.Printf("  Error writing package: %v\n", err)
+		return
+	}
+	if res.TextPath != "" {
+		fmt.Printf("  Saved: %s\n", res.TextPath)
+	}
+	if res.JSONPath != "" {
+		fmt.Printf("  Saved: %s\n", res.JSONPath)
+	}
+	if res.BaselinePath != "" {
+		fmt.Printf("  Saved baseline: %s\n", res.BaselinePath)
+	}
+	fmt.Println()
+}
+
+// writeForensicsPackage writes the package honoring the --format flag.
+// "both" (default) writes .txt + .json; "json"/"txt" select one. A baseline is
+// written when --baseline is set, regardless of format.
+func writeForensicsPackage(pkg *forensics.Package) (forensics.WriteResult, error) {
+	return pkg.Write(forensicsOutput, forensics.WriteOptions{
+		Format:   forensicsFormat,
+		Baseline: forensicsBaseline,
+	})
+}

--- a/go/internal/cli/forensics_test.go
+++ b/go/internal/cli/forensics_test.go
@@ -1,0 +1,129 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/nowifi/internal/forensics"
+)
+
+func TestForensicsCmd_Registered(t *testing.T) {
+	if forensicsCmd.Use != "forensics" {
+		t.Errorf("forensicsCmd.Use = %q, want forensics", forensicsCmd.Use)
+	}
+	registered := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "forensics" {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		t.Error("forensics subcommand not registered on rootCmd")
+	}
+}
+
+func TestForensicsCmd_FlagsDefined(t *testing.T) {
+	for _, name := range []string{"output", "format", "baseline", "baseline-file", "timeout", "portal-base"} {
+		if forensicsCmd.Flags().Lookup(name) == nil {
+			t.Errorf("forensics flag %q not defined", name)
+		}
+	}
+	// -o and -f shorthands.
+	if forensicsCmd.Flags().ShorthandLookup("o") == nil {
+		t.Error("forensics -o shorthand not defined")
+	}
+	if forensicsCmd.Flags().ShorthandLookup("f") == nil {
+		t.Error("forensics -f shorthand not defined")
+	}
+}
+
+func TestForensicsCmd_LongMentionsGuarantees(t *testing.T) {
+	long := forensicsCmd.Long
+	for _, want := range []string{"READ-ONLY", "NO SUDO", "LOCAL-ONLY"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("forensics Long help missing guarantee %q", want)
+		}
+	}
+}
+
+// TestWriteForensicsPackage_FormatSelection verifies the --format wiring writes
+// the right files, without any network access (package is built in-memory).
+func TestWriteForensicsPackage_FormatSelection(t *testing.T) {
+	tests := []struct {
+		format   string
+		wantTxt  bool
+		wantJSON bool
+	}{
+		{"both", true, true},
+		{"json", false, true},
+		{"txt", true, false},
+		{"", true, true}, // default treated as both
+	}
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			dir := t.TempDir()
+			// Set the package-level flags the helper reads.
+			forensicsOutput = dir
+			forensicsFormat = tt.format
+			forensicsBaseline = false
+			defer func() { forensicsOutput, forensicsFormat = "", "both" }()
+
+			pkg := &forensics.Package{TS: "20260530T120000Z", Iface: "en0", GW: "10.0.0.1", Provider: "test"}
+			res, err := writeForensicsPackage(pkg)
+			if err != nil {
+				t.Fatalf("writeForensicsPackage error: %v", err)
+			}
+
+			txtExists := res.TextPath != "" && fileExists(t, res.TextPath)
+			jsonExists := res.JSONPath != "" && fileExists(t, res.JSONPath)
+			if txtExists != tt.wantTxt {
+				t.Errorf("txt written=%t, want %t", txtExists, tt.wantTxt)
+			}
+			if jsonExists != tt.wantJSON {
+				t.Errorf("json written=%t, want %t", jsonExists, tt.wantJSON)
+			}
+			// Verify no stray files of the unwanted type landed in dir.
+			entries, _ := os.ReadDir(dir)
+			for _, e := range entries {
+				if !tt.wantTxt && strings.HasSuffix(e.Name(), ".txt") {
+					t.Errorf("unexpected .txt file %s for format %q", e.Name(), tt.format)
+				}
+				if !tt.wantJSON && strings.HasSuffix(e.Name(), ".json") {
+					t.Errorf("unexpected .json file %s for format %q", e.Name(), tt.format)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteForensicsPackage_BaselineFlag(t *testing.T) {
+	dir := t.TempDir()
+	forensicsOutput = dir
+	forensicsFormat = "both"
+	forensicsBaseline = true
+	defer func() { forensicsOutput, forensicsFormat, forensicsBaseline = "", "both", false }()
+
+	pkg := &forensics.Package{TS: "20260530T120000Z", Iface: "en0", GW: "10.0.0.1", Provider: "test"}
+	res, err := writeForensicsPackage(pkg)
+	if err != nil {
+		t.Fatalf("writeForensicsPackage error: %v", err)
+	}
+	if res.BaselinePath == "" || !fileExists(t, res.BaselinePath) {
+		t.Error("expected a baseline file to be written when --baseline is set")
+	}
+	if filepath.Base(res.BaselinePath) != "baseline-20260530T120000Z.txt" {
+		t.Errorf("unexpected baseline filename: %s", res.BaselinePath)
+	}
+}
+
+func fileExists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/go/internal/cli/root.go
+++ b/go/internal/cli/root.go
@@ -137,6 +137,7 @@ func init() {
 	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(scoreCmd)
+	rootCmd.AddCommand(forensicsCmd)
 }
 
 // loadConfigDefaults fills unset CLI flags from ~/.nowifi/config.json.

--- a/go/internal/forensics/collector.go
+++ b/go/internal/forensics/collector.go
@@ -1,0 +1,427 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+// Package forensics captures a portable, read-only diagnostic package that
+// records which egress channels survive captive-portal enforcement, so an
+// unsolved environment can be analyzed offline to build a working bypass.
+//
+// This is a Go port of forensics/captive-forensics.sh (sections 1-10 plus the
+// pax-api enforcement control-plane sweep). It is collection-only: no MAC
+// changes, no tunnels, no proxy, no network mutation, and it never uploads or
+// phones home. Output is written to disk and the saved paths are returned.
+//
+// Probing reuses the internal/probe package rather than reimplementing it.
+// Every probe degrades gracefully on missing privilege or timeout — a hung
+// probe never fails the whole run; the limitation is recorded in the package.
+package forensics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/detect"
+	"github.com/MikkoParkkola/nowifi/internal/platform"
+	"github.com/MikkoParkkola/nowifi/internal/probe"
+)
+
+const (
+	// DefaultTotalTimeout is the hard wall-clock cap for live collection.
+	// An offline, frustrated user must get a package fast even when some
+	// probes hang. Flag-overridable from the CLI.
+	DefaultTotalTimeout = 90 * time.Second
+
+	// paxAPITimeout bounds each individual pax-api control-plane request.
+	paxAPITimeout = 7 * time.Second
+
+	// paxBodyTruncate is the per-endpoint body cap (~2KB) for pax-api probes,
+	// except swagger.json which is captured fully (it is the enforcement model).
+	paxBodyTruncate = 2048
+)
+
+// Severity levels mirror the shell script's HIGH/MED/LOW taxonomy.
+const (
+	SeverityHigh = "HIGH"
+	SeverityMed  = "MED"
+	SeverityLow  = "LOW"
+)
+
+// Hole is a single exploitable egress channel that survived enforcement.
+// It maps to a nowifi bypass technique. This is the heart of the port:
+// the holes taxonomy, not the raw dumps.
+type Hole struct {
+	Technique string `json:"technique"`
+	Severity  string `json:"severity"`
+	Detail    string `json:"detail"`
+}
+
+// PaxEndpoint records one pax-api / enforcement control-plane probe.
+type PaxEndpoint struct {
+	Path        string `json:"path"`
+	StatusCode  int    `json:"status_code"`
+	ContentType string `json:"content_type,omitempty"`
+	Body        string `json:"body,omitempty"`
+	Truncated   bool   `json:"truncated,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// RawSections holds the additive captured state (sections 1-10) that
+// accompanies the ranked holes in the machine-readable package.
+type RawSections struct {
+	// Section 1: network state.
+	DNS  probe.DnsProbeResult  `json:"dns"`
+	IPv6 probe.Ipv6ProbeResult `json:"ipv6"`
+	// Section 2: authenticated-device enumeration (MAC-clone candidates).
+	ARP []platform.ArpEntry `json:"arp,omitempty"`
+	// Section 3: egress channel sweep under enforcement.
+	OpenPorts []probe.PortProbeResult `json:"open_ports,omitempty"`
+	QUIC      probe.PortProbeResult   `json:"quic"`
+	NTP       probe.PortProbeResult   `json:"ntp"`
+	// Section 4-6: recursion, DoH, ICMP.
+	ICMP probe.IcmpProbeResult `json:"icmp"`
+	DoH  probe.PortProbeResult `json:"doh"`
+	// Section 7: allowlist + SNI/domain-fronting.
+	Whitelists []probe.WhitelistResult `json:"whitelists,omitempty"`
+	Cloudflare probe.HttpsProbeResult  `json:"cloudflare"`
+	// Section 8/8c: portal/Kong surface + pax-api control plane.
+	PaxAPI []PaxEndpoint `json:"pax_api,omitempty"`
+	// Section 9: enforcement model.
+	SelfMAC string `json:"self_mac,omitempty"`
+	// Topology context.
+	Topology probe.SubnetTopology `json:"topology"`
+	// Limitations records degradations (missing privilege, timeouts) so the
+	// package is honest about what could not be captured.
+	Limitations []string `json:"limitations,omitempty"`
+}
+
+// Package is the complete forensic capture. The JSON form mirrors
+// forensics/holes-*.json: {ts, provider, iface, gw, holes[]} plus the raw
+// captured sections.
+type Package struct {
+	TS       string      `json:"ts"`
+	Provider string      `json:"provider"`
+	Iface    string      `json:"iface"`
+	GW       string      `json:"gw"`
+	Holes    []Hole      `json:"holes"`
+	Raw      RawSections `json:"raw"`
+}
+
+// Options configures a live collection run.
+type Options struct {
+	Iface    string
+	Stealth  bool
+	Provider string // optional override; derived from portal vendor otherwise
+	// PortalBase is the base URL for pax-api probes (e.g. https://portal.host).
+	// When empty it is derived from detected portal info, falling back to the
+	// gateway IP.
+	PortalBase string
+	// TotalTimeout is the hard wall-clock cap. Zero uses DefaultTotalTimeout.
+	TotalTimeout time.Duration
+	// httpClient is injectable for tests; nil uses a real short-timeout client.
+	httpClient *http.Client
+	// probes, when non-nil, is used instead of running a live ProbeAll sweep.
+	// The audit auto-trigger passes the probes already in scope; tests inject
+	// a fixed ProbeResults for deterministic, network-free runs.
+	probes *probe.ProbeResults
+	// arp, when non-nil, is used instead of platform.GetARPTable.
+	arp []platform.ArpEntry
+	// portal, when non-nil, is used instead of detect.DetectPortal.
+	portal *detect.PortalInfo
+	// selfMAC, when non-empty, is used instead of platform.GetCurrentMAC.
+	selfMAC string
+	// gateway, when non-empty, is used instead of platform.GetGateway.
+	gateway string
+	// now is injectable for deterministic timestamps in tests.
+	now func() time.Time
+}
+
+// WithProbes returns a copy of opts that reuses pre-built probe results
+// instead of running a live ProbeAll sweep. The audit auto-trigger uses this
+// to pass the probes already in scope, avoiding a fresh sweep inside the
+// session maintain loop.
+func (o Options) WithProbes(probes *probe.ProbeResults) Options {
+	o.probes = probes
+	return o
+}
+
+// paxEndpoints is the enforcement control-plane surface (section 8c).
+// swagger.json is captured fully; the rest truncate to ~2KB.
+var paxEndpoints = []string{
+	"/pax-api-service/session",
+	"/pax-api-service/device",
+	"/pax-api-service/status",
+	"/pax-api-service/quota",
+	"/pax-api-service/plans",
+	"/pax-api-service/health",
+	"/pax-api-service/api-docs",
+	"/pax-api-service/swagger.json",
+	"/portal-versions.json",
+}
+
+// Collect runs a live, read-only forensic capture under a hard time cap and
+// returns the assembled package. Partial results still serialize: on timeout
+// it records the limitation and returns whatever sections completed.
+func Collect(opts Options) *Package {
+	if opts.now == nil {
+		opts.now = time.Now
+	}
+	if opts.TotalTimeout <= 0 {
+		opts.TotalTimeout = DefaultTotalTimeout
+	}
+	ts := opts.now().UTC().Format("20060102T150405Z")
+
+	pkg := &Package{TS: ts, Iface: opts.Iface}
+
+	// raw is filled incrementally by the worker goroutine under mu. On timeout
+	// the main path locks and snapshots whatever has completed so far, so a
+	// hung pax-api fetch never discards the probe sweep, ARP, or MAC that
+	// already landed. The package is genuinely partial, not empty.
+	var mu sync.Mutex
+	raw := &RawSections{}
+	var portal *detect.PortalInfo
+
+	deadline := time.After(opts.TotalTimeout)
+	done := make(chan struct{})
+
+	go func() {
+		// Portal detection (section 8) — also feeds provider + pax base.
+		p := opts.portal
+		if p == nil {
+			p = detect.DetectPortal(opts.Iface)
+		}
+		mu.Lock()
+		portal = p
+		mu.Unlock()
+
+		// Section 9: enforcement model — your MAC.
+		selfMAC := opts.selfMAC
+		var selfMACLimit string
+		if selfMAC == "" {
+			if mac, err := platform.GetCurrentMAC(opts.Iface); err == nil {
+				selfMAC = mac
+			} else {
+				selfMACLimit = "self MAC unavailable (interface query failed): " + err.Error()
+			}
+		}
+		mu.Lock()
+		raw.SelfMAC = selfMAC
+		if selfMACLimit != "" {
+			raw.Limitations = append(raw.Limitations, selfMACLimit)
+		}
+		mu.Unlock()
+
+		// Sections 1,3-7: reuse the probe sweep. Never reimplement probing.
+		var probes *probe.ProbeResults
+		if opts.probes != nil {
+			probes = opts.probes
+		} else {
+			probes = probe.ProbeAll(opts.Iface, opts.Stealth, "")
+		}
+		// Topology (cross-subnet portal detection).
+		portalIP := ""
+		if p != nil {
+			portalIP = p.PortalIP
+		}
+		topology := probe.ProbeTopology(opts.Iface, portalIP)
+		mu.Lock()
+		raw.DNS = probes.DNS
+		raw.ICMP = probes.ICMP
+		raw.IPv6 = probes.IPv6
+		raw.Cloudflare = probes.Cloudflare
+		raw.Whitelists = probes.Whitelists
+		raw.OpenPorts = probes.OpenPorts
+		raw.QUIC = probes.QUIC
+		raw.NTP = probes.NTP
+		raw.DoH = probes.DoH
+		raw.Topology = topology
+		mu.Unlock()
+
+		// Section 2: ARP table = MAC-clone candidates. We do NOT replicate the
+		// shell's /24 ping-sweep — that fights "reuse, don't reimplement",
+		// risks the time cap, and flirts with the no-mutation rule. We read the
+		// existing ARP cache and record the degradation.
+		arp := opts.arp
+		var arpLimit string
+		if arp == nil {
+			var err error
+			arp, err = platform.GetARPTable()
+			if err != nil {
+				arpLimit = "ARP table unavailable: " + err.Error()
+			}
+		}
+		mu.Lock()
+		raw.ARP = arp
+		if arpLimit != "" {
+			raw.Limitations = append(raw.Limitations, arpLimit)
+		}
+		raw.Limitations = append(raw.Limitations,
+			"neighbor set limited to existing ARP cache (no active subnet sweep — read-only)")
+		mu.Unlock()
+
+		// Section 8c: pax-api enforcement control plane (the slowest section —
+		// the realistic timeout trigger on a high-RTT link).
+		base := opts.PortalBase
+		if base == "" {
+			base = derivePortalBase(p, opts.gateway, opts.Iface)
+		}
+		var pax []PaxEndpoint
+		var paxLimit string
+		if base != "" {
+			pax = probePaxAPI(opts.httpClient, base)
+		} else {
+			paxLimit = "pax-api base URL could not be derived (no portal host or gateway)"
+		}
+		mu.Lock()
+		raw.PaxAPI = pax
+		if paxLimit != "" {
+			raw.Limitations = append(raw.Limitations, paxLimit)
+		}
+		mu.Unlock()
+
+		close(done)
+	}()
+
+	timedOut := false
+	select {
+	case <-done:
+	case <-deadline:
+		timedOut = true
+	}
+
+	// Snapshot the (possibly partial) raw sections under the lock.
+	mu.Lock()
+	if timedOut {
+		raw.Limitations = append(raw.Limitations, fmt.Sprintf(
+			"collection exceeded total time cap (%s) — package is partial; some sections may be missing",
+			opts.TotalTimeout))
+	}
+	pkg.Raw = *raw
+	portalSnapshot := portal
+	mu.Unlock()
+	portal = portalSnapshot
+
+	// Gateway.
+	pkg.GW = opts.gateway
+	if pkg.GW == "" {
+		if portal != nil && portal.Gateway != "" {
+			pkg.GW = portal.Gateway
+		} else if gw, err := platform.GetGateway(opts.Iface); err == nil {
+			pkg.GW = gw
+		}
+	}
+
+	// Provider.
+	pkg.Provider = opts.Provider
+	if pkg.Provider == "" {
+		pkg.Provider = deriveProvider(portal)
+	}
+
+	pkg.Holes = MapHoles(&pkg.Raw)
+	return pkg
+}
+
+// deriveProvider produces a stable provider slug from portal vendor, avoiding
+// any import back into the cli package (cli imports forensics, not vice-versa).
+func deriveProvider(portal *detect.PortalInfo) string {
+	if portal == nil || portal.Vendor == "" {
+		return "unknown"
+	}
+	slug := strings.ToLower(portal.Vendor)
+	slug = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r == ' ', r == '-', r == '/', r == '.':
+			return '_'
+		default:
+			return -1
+		}
+	}, slug)
+	for strings.Contains(slug, "__") {
+		slug = strings.ReplaceAll(slug, "__", "_")
+	}
+	slug = strings.Trim(slug, "_")
+	if slug == "" {
+		return "unknown"
+	}
+	return slug
+}
+
+// derivePortalBase builds the pax-api base URL from detected portal info,
+// falling back to the gateway IP.
+func derivePortalBase(portal *detect.PortalInfo, gateway, iface string) string {
+	if portal != nil {
+		if portal.PortalURL != "" {
+			if u, err := url.Parse(portal.PortalURL); err == nil && u.Host != "" {
+				return u.Scheme + "://" + u.Host
+			}
+		}
+		if portal.PortalIP != "" {
+			return "https://" + portal.PortalIP
+		}
+		if portal.Gateway != "" {
+			return "https://" + portal.Gateway
+		}
+	}
+	if gateway != "" {
+		return "https://" + gateway
+	}
+	if gw, err := platform.GetGateway(iface); err == nil && gw != "" {
+		return "https://" + gw
+	}
+	return ""
+}
+
+// probePaxAPI fetches the enforcement control-plane endpoints with a short
+// per-request timeout, capturing status and a truncated body (full for
+// swagger.json). Read-only GETs; never mutates anything.
+func probePaxAPI(client *http.Client, base string) []PaxEndpoint {
+	if client == nil {
+		client = &http.Client{Timeout: paxAPITimeout}
+	}
+	base = strings.TrimRight(base, "/")
+	out := make([]PaxEndpoint, 0, len(paxEndpoints))
+	for _, ep := range paxEndpoints {
+		out = append(out, fetchPaxEndpoint(client, base, ep))
+	}
+	return out
+}
+
+func fetchPaxEndpoint(client *http.Client, base, ep string) PaxEndpoint {
+	res := PaxEndpoint{Path: ep}
+	ctx, cancel := context.WithTimeout(context.Background(), paxAPITimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+ep, nil)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	defer resp.Body.Close()
+	res.StatusCode = resp.StatusCode
+	res.ContentType = resp.Header.Get("Content-Type")
+
+	// swagger.json is the enforcement model — capture it fully. Others truncate.
+	full := strings.HasSuffix(ep, "swagger.json")
+	limit := int64(paxBodyTruncate)
+	if full {
+		limit = 1 << 20 // 1MB safety ceiling even for "full".
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if !full && int64(len(body)) > int64(paxBodyTruncate) {
+		body = body[:paxBodyTruncate]
+		res.Truncated = true
+	}
+	res.Body = string(body)
+	return res
+}

--- a/go/internal/forensics/collector_test.go
+++ b/go/internal/forensics/collector_test.go
@@ -1,0 +1,469 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package forensics
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/nowifi/internal/detect"
+	"github.com/MikkoParkkola/nowifi/internal/platform"
+	"github.com/MikkoParkkola/nowifi/internal/probe"
+)
+
+// fullRaw builds a RawSections fixture in which every channel is open, so the
+// full holes taxonomy is exercised without touching the network.
+func fullRaw() *RawSections {
+	return &RawSections{
+		DNS: probe.DnsProbeResult{IsOpen: true, Resolvers: []probe.ResolverResult{
+			{IP: "8.8.8.8", Name: "Google", Resolved: "93.184.216.34"},
+			{IP: "1.1.1.1", Name: "Cloudflare", Resolved: "93.184.216.34"},
+		}},
+		ICMP: probe.IcmpProbeResult{IsOpen: true, Details: "echo reaches 1.1.1.1"},
+		IPv6: probe.Ipv6ProbeResult{IsOpen: true, Address: "2001:db8::1"},
+		DoH:  probe.PortProbeResult{Port: 443, Protocol: "doh", IsOpen: true},
+		QUIC: probe.PortProbeResult{Port: 443, Protocol: "udp", IsOpen: true},
+		NTP:  probe.PortProbeResult{Port: 123, Protocol: "udp", IsOpen: true},
+		OpenPorts: []probe.PortProbeResult{
+			{Port: 53, Protocol: "tcp", IsOpen: true, Service: "DNS"},
+			{Port: 443, Protocol: "tcp", IsOpen: true, Service: "HTTPS"},
+			{Port: 22, Protocol: "tcp", IsOpen: true, Service: "SSH"},
+			{Port: 80, Protocol: "tcp", IsOpen: false, Service: "HTTP"},
+		},
+		Whitelists: []probe.WhitelistResult{
+			{Domain: "cloudflare.com", IsOpen: true, StatusCode: 200},
+			{Domain: "blocked.example", IsOpen: false},
+		},
+		ARP: []platform.ArpEntry{
+			{IP: "172.19.248.1", MAC: "aa:bb:cc:dd:ee:01", Interface: "en0"},
+			{IP: "172.19.248.2", MAC: "aa:bb:cc:dd:ee:02", Interface: "en0"},
+			{IP: "172.19.248.9", MAC: "de:ad:be:ef:00:00", Interface: "en0"}, // self
+		},
+		SelfMAC: "de:ad:be:ef:00:00",
+		PaxAPI: []PaxEndpoint{
+			{Path: "/pax-api-service/session", StatusCode: 200, ContentType: "application/json"},
+			{Path: "/pax-api-service/quota", StatusCode: 404},
+			{Path: "/pax-api-service/swagger.json", StatusCode: 200, ContentType: "application/json"},
+		},
+	}
+}
+
+func techniqueCounts(holes []Hole) map[string]int {
+	m := map[string]int{}
+	for _, h := range holes {
+		m[h.Technique]++
+	}
+	return m
+}
+
+func TestMapHoles_FullTaxonomy(t *testing.T) {
+	holes := MapHoles(fullRaw())
+	counts := techniqueCounts(holes)
+
+	tests := []struct {
+		technique string
+		wantMin   int
+	}{
+		{"mac_clone_idle", 1},
+		{"tcp53_tunnel", 1},
+		{"tcp443_tunnel", 1},
+		{"ssh_egress", 1},
+		{"quic_tunnel", 1}, // from QUIC probe and/or UDP/443 port
+		{"ntp_tunnel", 1},
+		{"dns_tunnel", 2}, // one per recursive resolver
+		{"doh_tunnel", 1},
+		{"icmp_tunnel", 1},
+		{"domain_front", 1},
+		{"portal_api_session", 1},
+		{"mac_rotate", 1},
+	}
+	for _, tt := range tests {
+		if counts[tt.technique] < tt.wantMin {
+			t.Errorf("technique %q: got %d, want >= %d", tt.technique, counts[tt.technique], tt.wantMin)
+		}
+	}
+}
+
+func TestMapHoles_RankingHighBeforeMed(t *testing.T) {
+	holes := MapHoles(fullRaw())
+	seenMed := false
+	for _, h := range holes {
+		if h.Severity == SeverityMed {
+			seenMed = true
+		}
+		if h.Severity == SeverityHigh && seenMed {
+			t.Errorf("HIGH hole %q appeared after a MED hole — ranking broken", h.Technique)
+		}
+	}
+}
+
+func TestMapHoles_EmptyAndNil(t *testing.T) {
+	if got := MapHoles(nil); len(got) != 0 {
+		t.Errorf("MapHoles(nil) = %d holes, want 0", len(got))
+	}
+	if got := MapHoles(&RawSections{}); len(got) != 0 {
+		t.Errorf("MapHoles(empty) = %d holes, want 0", len(got))
+	}
+}
+
+func TestMapHoles_SelfMACNotCounted(t *testing.T) {
+	raw := &RawSections{
+		SelfMAC: "de:ad:be:ef:00:00",
+		ARP: []platform.ArpEntry{
+			{IP: "10.0.0.1", MAC: "DE:AD:BE:EF:00:00", Interface: "en0"}, // self, uppercase
+		},
+	}
+	for _, h := range MapHoles(raw) {
+		if h.Technique == "mac_clone_idle" {
+			t.Error("self MAC (case-insensitive) was counted as a clone candidate")
+		}
+	}
+}
+
+func TestDiffBaseline(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  []Hole
+		baseline []Hole
+		want     []string
+	}{
+		{
+			name:     "intersection only",
+			current:  []Hole{{Technique: "dns_tunnel", Severity: SeverityHigh}, {Technique: "icmp_tunnel", Severity: SeverityHigh}},
+			baseline: []Hole{{Technique: "dns_tunnel", Severity: SeverityHigh}, {Technique: "doh_tunnel", Severity: SeverityHigh}},
+			want:     []string{"dns_tunnel"},
+		},
+		{
+			name:     "no overlap",
+			current:  []Hole{{Technique: "ssh_egress", Severity: SeverityHigh}},
+			baseline: []Hole{{Technique: "ntp_tunnel", Severity: SeverityMed}},
+			want:     nil,
+		},
+		{
+			name:     "dedup repeated technique",
+			current:  []Hole{{Technique: "dns_tunnel"}, {Technique: "dns_tunnel"}},
+			baseline: []Hole{{Technique: "dns_tunnel"}},
+			want:     []string{"dns_tunnel"},
+		},
+		{
+			name:     "empty baseline yields nothing",
+			current:  []Hole{{Technique: "dns_tunnel"}},
+			baseline: nil,
+			want:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DiffBaseline(tt.current, tt.baseline)
+			var names []string
+			for _, h := range got {
+				names = append(names, h.Technique)
+			}
+			if strings.Join(names, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("DiffBaseline() = %v, want %v", names, tt.want)
+			}
+		})
+	}
+}
+
+func TestBaselineRoundTrip(t *testing.T) {
+	pkg := &Package{TS: "20260530T120000Z", Iface: "en0", GW: "10.0.0.1", Provider: "panasonic"}
+	pkg.Raw = *fullRaw()
+	pkg.Holes = MapHoles(&pkg.Raw)
+
+	parsed := ParseBaseline(pkg.Baseline())
+	if len(parsed) != len(pkg.Holes) {
+		t.Fatalf("round-trip hole count: got %d, want %d", len(parsed), len(pkg.Holes))
+	}
+	// Every original technique must survive the round trip.
+	orig := techniqueCounts(pkg.Holes)
+	got := techniqueCounts(parsed)
+	for k, v := range orig {
+		if got[k] != v {
+			t.Errorf("technique %q: round-trip got %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+func TestParseBaseline_SkipsCommentsAndBlanks(t *testing.T) {
+	in := "# header\n\ndns_tunnel|HIGH|works\n   \nicmp_tunnel|HIGH\nbad-no-pipe\n"
+	got := ParseBaseline(in)
+	if len(got) != 2 {
+		t.Fatalf("ParseBaseline got %d holes, want 2: %+v", len(got), got)
+	}
+	if got[0].Technique != "dns_tunnel" || got[0].Detail != "works" {
+		t.Errorf("unexpected first hole: %+v", got[0])
+	}
+}
+
+func TestPackageJSON_MirrorsReferenceShape(t *testing.T) {
+	pkg := &Package{TS: "20260530T120000Z", Provider: "panasonic_nordic_sky", Iface: "en0", GW: "172.19.248.1"}
+	pkg.Raw = *fullRaw()
+	pkg.Holes = MapHoles(&pkg.Raw)
+
+	data, err := pkg.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"ts", "provider", "iface", "gw", "holes", "raw"} {
+		if _, ok := top[key]; !ok {
+			t.Errorf("JSON missing top-level key %q", key)
+		}
+	}
+	// holes[] entries must carry technique/severity/detail.
+	var holes []Hole
+	if err := json.Unmarshal(top["holes"], &holes); err != nil {
+		t.Fatalf("unmarshal holes: %v", err)
+	}
+	if len(holes) == 0 {
+		t.Fatal("expected non-empty holes")
+	}
+	if holes[0].Technique == "" || holes[0].Severity == "" {
+		t.Errorf("hole missing fields: %+v", holes[0])
+	}
+}
+
+func TestText_NoPanicAndContainsSections(t *testing.T) {
+	pkg := &Package{TS: "20260530T120000Z", Iface: "en0", GW: "10.0.0.1", Provider: "test"}
+	pkg.Raw = *fullRaw()
+	pkg.Holes = MapHoles(&pkg.Raw)
+	txt := pkg.Text()
+	for _, want := range []string{"NETWORK STATE", "MAC-CLONE CANDIDATES", "HOLES FOUND", "pax-api"} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("Text() missing section %q", want)
+		}
+	}
+}
+
+func TestWrite_ProducesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	pkg := &Package{TS: "20260530T120000Z", Iface: "en0", GW: "10.0.0.1", Provider: "test"}
+	pkg.Raw = *fullRaw()
+	pkg.Holes = MapHoles(&pkg.Raw)
+
+	res, err := pkg.Write(dir, WriteOptions{Format: "both", Baseline: true})
+	if err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	for _, p := range []string{res.TextPath, res.JSONPath, res.BaselinePath} {
+		if p == "" {
+			t.Fatal("Write() returned an empty path")
+		}
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected file %s: %v", p, err)
+		}
+	}
+	if filepath.Base(res.TextPath) != "holes-20260530T120000Z.txt" {
+		t.Errorf("unexpected text filename: %s", res.TextPath)
+	}
+	if filepath.Base(res.JSONPath) != "holes-20260530T120000Z.json" {
+		t.Errorf("unexpected json filename: %s", res.JSONPath)
+	}
+}
+
+func TestProbePaxAPI_TruncatesAndCapturesSwaggerFully(t *testing.T) {
+	bigBody := strings.Repeat("A", paxBodyTruncate*3)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "swagger.json"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(bigBody))
+		case strings.HasSuffix(r.URL.Path, "/quota"):
+			w.WriteHeader(404)
+		default:
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(bigBody))
+		}
+	}))
+	defer srv.Close()
+
+	eps := probePaxAPI(srv.Client(), srv.URL)
+	var swagger, session *PaxEndpoint
+	for i := range eps {
+		switch {
+		case strings.HasSuffix(eps[i].Path, "swagger.json"):
+			swagger = &eps[i]
+		case strings.HasSuffix(eps[i].Path, "/session"):
+			session = &eps[i]
+		}
+	}
+	if swagger == nil || session == nil {
+		t.Fatal("expected swagger and session endpoints in results")
+	}
+	if swagger.Truncated {
+		t.Error("swagger.json must be captured fully, not truncated")
+	}
+	if len(swagger.Body) != len(bigBody) {
+		t.Errorf("swagger body len = %d, want %d (full)", len(swagger.Body), len(bigBody))
+	}
+	if !session.Truncated || len(session.Body) != paxBodyTruncate {
+		t.Errorf("session body should be truncated to %d, got len %d truncated=%t",
+			paxBodyTruncate, len(session.Body), session.Truncated)
+	}
+}
+
+// TestCollect_NetworkFree_InjectedProbes verifies that Collect assembles a
+// complete package from injected probes + ARP + portal + a fake pax-api,
+// with zero live network access.
+func TestCollect_NetworkFree_InjectedProbes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	raw := fullRaw()
+	probes := &probe.ProbeResults{
+		DNS: raw.DNS, ICMP: raw.ICMP, IPv6: raw.IPv6, Cloudflare: raw.Cloudflare,
+		Whitelists: raw.Whitelists, OpenPorts: raw.OpenPorts,
+		QUIC: raw.QUIC, NTP: raw.NTP, DoH: raw.DoH,
+	}
+	opts := Options{
+		Iface:      "en0",
+		Provider:   "test_provider",
+		PortalBase: srv.URL,
+		httpClient: srv.Client(),
+		probes:     probes,
+		arp:        raw.ARP,
+		selfMAC:    raw.SelfMAC,
+		gateway:    "172.19.248.1",
+		portal:     &detect.PortalInfo{IsCaptive: true, Vendor: "Test", PortalIP: "172.19.248.1"},
+		now:        func() time.Time { return time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC) },
+	}
+	pkg := Collect(opts)
+
+	if pkg.TS != "20260530T120000Z" {
+		t.Errorf("TS = %q, want injected timestamp", pkg.TS)
+	}
+	if pkg.Provider != "test_provider" || pkg.GW != "172.19.248.1" || pkg.Iface != "en0" {
+		t.Errorf("metadata wrong: %+v", pkg)
+	}
+	if len(pkg.Holes) == 0 {
+		t.Error("expected holes from injected open channels")
+	}
+	if len(pkg.Raw.PaxAPI) != len(paxEndpoints) {
+		t.Errorf("pax-api endpoints = %d, want %d", len(pkg.Raw.PaxAPI), len(paxEndpoints))
+	}
+	// A live 200 endpoint should surface a portal_api_session hole.
+	if techniqueCounts(pkg.Holes)["portal_api_session"] == 0 {
+		t.Error("expected portal_api_session hole from live pax-api endpoint")
+	}
+}
+
+// slowRoundTripper sleeps before every response, making pax-api the slow
+// section so a tight TotalTimeout fires during pax fetches.
+type slowRoundTripper struct{ delay time.Duration }
+
+func (s slowRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	time.Sleep(s.delay)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Request:    req,
+	}, nil
+}
+
+// TestCollect_TimeoutSalvagesCompletedSections proves the timeout path is
+// genuinely partial, not empty: probes/ARP/MAC are injected and complete
+// instantly, only pax-api is slow, so on a tight cap the package retains the
+// salvaged sections and records the cap limitation.
+func TestCollect_TimeoutSalvagesCompletedSections(t *testing.T) {
+	raw := fullRaw()
+	probes := &probe.ProbeResults{
+		DNS: raw.DNS, ICMP: raw.ICMP, IPv6: raw.IPv6, Cloudflare: raw.Cloudflare,
+		Whitelists: raw.Whitelists, OpenPorts: raw.OpenPorts,
+		QUIC: raw.QUIC, NTP: raw.NTP, DoH: raw.DoH,
+	}
+	opts := Options{
+		Iface:        "en0",
+		Provider:     "test_provider",
+		PortalBase:   "https://portal.example",
+		httpClient:   &http.Client{Transport: slowRoundTripper{delay: 500 * time.Millisecond}},
+		probes:       probes,
+		arp:          raw.ARP,
+		selfMAC:      raw.SelfMAC,
+		gateway:      "10.0.0.1",
+		portal:       &detect.PortalInfo{IsCaptive: true, Vendor: "Test"},
+		TotalTimeout: 30 * time.Millisecond,
+		now:          func() time.Time { return time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC) },
+	}
+	pkg := Collect(opts)
+
+	// Salvaged section: SelfMAC must survive the timeout.
+	if pkg.Raw.SelfMAC != raw.SelfMAC {
+		t.Errorf("timeout discarded SelfMAC: got %q, want %q (package should be partial, not empty)",
+			pkg.Raw.SelfMAC, raw.SelfMAC)
+	}
+	// Metadata always survives.
+	if pkg.Provider != "test_provider" || pkg.GW != "10.0.0.1" {
+		t.Errorf("timeout lost metadata: %+v", pkg)
+	}
+	// The cap limitation must be recorded.
+	found := false
+	for _, l := range pkg.Raw.Limitations {
+		if strings.Contains(l, "total time cap") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a time-cap limitation note, got %v", pkg.Raw.Limitations)
+	}
+}
+
+func TestDeriveProvider(t *testing.T) {
+	tests := []struct {
+		vendor string
+		want   string
+	}{
+		{"Panasonic Avionics", "panasonic_avionics"},
+		{"Nordic-Sky", "nordic_sky"},
+		{"", "unknown"},
+		{"Kong/Squid", "kong_squid"},
+	}
+	for _, tt := range tests {
+		got := deriveProvider(&detect.PortalInfo{Vendor: tt.vendor})
+		if got != tt.want {
+			t.Errorf("deriveProvider(%q) = %q, want %q", tt.vendor, got, tt.want)
+		}
+	}
+	if got := deriveProvider(nil); got != "unknown" {
+		t.Errorf("deriveProvider(nil) = %q, want unknown", got)
+	}
+}
+
+func TestDerivePortalBase(t *testing.T) {
+	tests := []struct {
+		name    string
+		portal  *detect.PortalInfo
+		gateway string
+		want    string
+	}{
+		{"from portal URL", &detect.PortalInfo{PortalURL: "https://portal.example.com/login"}, "", "https://portal.example.com"},
+		{"from portal IP", &detect.PortalInfo{PortalIP: "172.16.0.1"}, "", "https://172.16.0.1"},
+		{"from gateway fallback", &detect.PortalInfo{}, "10.0.0.1", "https://10.0.0.1"},
+		{"nil portal gateway fallback", nil, "10.0.0.1", "https://10.0.0.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := derivePortalBase(tt.portal, tt.gateway, "")
+			if got != tt.want {
+				t.Errorf("derivePortalBase() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/forensics/holes.go
+++ b/go/internal/forensics/holes.go
@@ -1,0 +1,284 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package forensics
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MapHoles is the heart of the port: it translates raw probe results into the
+// ranked holes taxonomy used by the shell script and the reference JSON. Each
+// open channel that survives enforcement maps to a nowifi bypass technique.
+//
+// Pure function — no I/O, no network — so it is directly table-testable by
+// injecting a RawSections fixture.
+func MapHoles(raw *RawSections) []Hole {
+	var holes []Hole
+	if raw == nil {
+		return holes
+	}
+
+	// Section 2: authenticated-device enumeration. >1 neighbor MAC (excluding
+	// self) is a MAC-clone candidate pool.
+	others := 0
+	self := strings.ToLower(raw.SelfMAC)
+	for _, e := range raw.ARP {
+		if strings.ToLower(e.MAC) != self {
+			others++
+		}
+	}
+	if others >= 1 {
+		holes = append(holes, Hole{
+			Technique: "mac_clone_idle",
+			Severity:  SeverityHigh,
+			Detail: fmt.Sprintf("%d neighbor MAC(s) visible on subnet; clone an idle paid device to inherit its session",
+				others),
+		})
+	}
+
+	// Section 3: TCP/UDP egress sweep. Open = exploitable hole.
+	for _, p := range raw.OpenPorts {
+		if !p.IsOpen {
+			continue
+		}
+		switch p.Port {
+		case 53:
+			if strings.EqualFold(p.Protocol, "udp") {
+				holes = append(holes, Hole{"dns_tunnel", SeverityHigh,
+					"UDP/53 egress open — iodine/dnscat2 DNS tunnel viable"})
+			} else {
+				holes = append(holes, Hole{"tcp53_tunnel", SeverityHigh,
+					"TCP/53 egress open — chisel/ssh over :53"})
+			}
+		case 443:
+			if strings.EqualFold(p.Protocol, "udp") {
+				holes = append(holes, Hole{"quic_tunnel", SeverityMed,
+					"UDP/443 (QUIC) egress open — masque/quic tunnel"})
+			} else {
+				holes = append(holes, Hole{"tcp443_tunnel", SeverityMed,
+					"TCP/443 egress open to non-allowlisted IP — wstunnel/chisel/openvpn over :443"})
+			}
+		case 22:
+			holes = append(holes, Hole{"ssh_egress", SeverityHigh,
+				"TCP/22 open — direct SSH SOCKS proxy"})
+		case 123:
+			holes = append(holes, Hole{"ntp_tunnel", SeverityMed,
+				"UDP/123 (NTP) egress open — covert channel"})
+		}
+	}
+
+	// Section 3 (dedicated probes): QUIC, NTP.
+	if raw.QUIC.IsOpen {
+		holes = append(holes, Hole{"quic_tunnel", SeverityMed,
+			"UDP/443 (QUIC) reaches the internet — masque/quic tunnel"})
+	}
+	if raw.NTP.IsOpen {
+		holes = append(holes, Hole{"ntp_tunnel", SeverityMed,
+			"UDP/123 (NTP) reaches the internet — covert channel"})
+	}
+
+	// Section 4: DNS external recursion (the classic survivor).
+	if raw.DNS.IsOpen {
+		for _, r := range raw.DNS.Resolvers {
+			holes = append(holes, Hole{"dns_tunnel", SeverityHigh,
+				fmt.Sprintf("resolver %s returns external A records — full recursion = DNS tunnel works", r.IP)})
+		}
+		if len(raw.DNS.Resolvers) == 0 {
+			holes = append(holes, Hole{"dns_tunnel", SeverityHigh,
+				"external DNS recursion reachable — DNS tunnel viable"})
+		}
+	}
+
+	// Section 5: DoH endpoints.
+	if raw.DoH.IsOpen {
+		holes = append(holes, Hole{"doh_tunnel", SeverityHigh,
+			"DoH endpoint reachable + answers — DoH tunnel / cloudflared works"})
+	}
+
+	// Section 6: ICMP echo to the internet.
+	if raw.ICMP.IsOpen {
+		holes = append(holes, Hole{"icmp_tunnel", SeverityHigh,
+			"ICMP echo reaches the internet — ptunnel-ng covert channel"})
+	}
+
+	// Section 7: allowlist + SNI/domain-fronting.
+	for _, w := range raw.Whitelists {
+		if w.IsOpen {
+			holes = append(holes, Hole{"domain_front", SeverityMed,
+				fmt.Sprintf("allowlisted host %s returns %d — SNI/domain-fronting hop candidate", w.Domain, w.StatusCode)})
+		}
+	}
+
+	// Section 8c: a live enforcement endpoint is a PoC surface.
+	for _, ep := range raw.PaxAPI {
+		if ep.StatusCode >= 200 && ep.StatusCode < 500 && ep.StatusCode != 404 {
+			holes = append(holes, Hole{"portal_api_session", SeverityMed,
+				fmt.Sprintf("enforcement endpoint %s is live (HTTP %d, %s) — inspect/replay for session/quota state",
+					ep.Path, ep.StatusCode, ep.ContentType)})
+		}
+	}
+
+	// Section 9: enforcement model — per-MAC quota reset vector.
+	if raw.SelfMAC != "" {
+		holes = append(holes, Hole{"mac_rotate", SeverityMed,
+			"if quota is per-MAC, a fresh random MAC resets it"})
+	}
+
+	return rankHoles(holes)
+}
+
+// rankHoles orders holes HIGH, then MED, then LOW, preserving discovery order
+// within each tier. Deterministic for stable test assertions and reports.
+func rankHoles(holes []Hole) []Hole {
+	order := map[string]int{SeverityHigh: 0, SeverityMed: 1, SeverityLow: 2}
+	sort.SliceStable(holes, func(i, j int) bool {
+		return order[holes[i].Severity] < order[holes[j].Severity]
+	})
+	return holes
+}
+
+// holeKey identifies a hole channel for diffing (technique + severity-agnostic
+// channel). We key on technique alone: the same technique open in two runs is
+// the reliable channel regardless of how the detail string was phrased.
+func holeKey(h Hole) string { return h.Technique }
+
+// DiffBaseline returns the holes that are open in BOTH the current capture and
+// the baseline (set intersection by technique). Channels open in both runs
+// survive enforcement and are the reliable holes (section 10).
+//
+// Pure function — table-testable without any network.
+func DiffBaseline(current, baseline []Hole) []Hole {
+	base := make(map[string]bool, len(baseline))
+	for _, h := range baseline {
+		base[holeKey(h)] = true
+	}
+	seen := make(map[string]bool)
+	var out []Hole
+	for _, h := range current {
+		k := holeKey(h)
+		if base[k] && !seen[k] {
+			seen[k] = true
+			out = append(out, h)
+		}
+	}
+	return rankHoles(out)
+}
+
+// JSON serializes the package to indented JSON mirroring forensics/holes-*.json
+// ({ts, provider, iface, gw, holes[]} plus raw sections).
+func (p *Package) JSON() ([]byte, error) {
+	return json.MarshalIndent(p, "", "  ")
+}
+
+// Text renders the human-readable .txt report (the HOLES section plus a
+// captured-state summary), matching the shell script's report shape.
+func (p *Package) Text() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# nowifi captive forensics — %s\n", p.TS)
+	fmt.Fprintf(&b, "# iface=%s gw=%s provider=%s self_mac=%s\n", p.Iface, p.GW, p.Provider, p.Raw.SelfMAC)
+	b.WriteString("# read-only capture: no MAC change, no tunnel, no proxy, no upload\n\n")
+
+	b.WriteString("===== 1. NETWORK STATE =====\n")
+	fmt.Fprintf(&b, "  DNS open: %t — %s\n", p.Raw.DNS.IsOpen, p.Raw.DNS.Details)
+	fmt.Fprintf(&b, "  IPv6 open: %t — %s\n", p.Raw.IPv6.IsOpen, p.Raw.IPv6.Details)
+	if p.Raw.Topology.Details != "" {
+		fmt.Fprintf(&b, "  topology: %s\n", p.Raw.Topology.Details)
+	}
+
+	b.WriteString("\n===== 2. MAC-CLONE CANDIDATES =====\n")
+	if len(p.Raw.ARP) == 0 {
+		b.WriteString("  (no neighbor MACs in ARP cache)\n")
+	}
+	for _, e := range p.Raw.ARP {
+		fmt.Fprintf(&b, "  %-15s  %s  (%s)\n", e.IP, e.MAC, e.Interface)
+	}
+
+	b.WriteString("\n===== 3-7. EGRESS / RECURSION / DoH / ICMP / ALLOWLIST =====\n")
+	for _, prt := range p.Raw.OpenPorts {
+		if prt.IsOpen {
+			fmt.Fprintf(&b, "  %s/%d OPEN (%s)\n", prt.Protocol, prt.Port, prt.Service)
+		}
+	}
+	fmt.Fprintf(&b, "  QUIC open: %t | NTP open: %t | DoH open: %t | ICMP open: %t\n",
+		p.Raw.QUIC.IsOpen, p.Raw.NTP.IsOpen, p.Raw.DoH.IsOpen, p.Raw.ICMP.IsOpen)
+	for _, w := range p.Raw.Whitelists {
+		fmt.Fprintf(&b, "  allow? %s -> open=%t (%d)\n", w.Domain, w.IsOpen, w.StatusCode)
+	}
+
+	b.WriteString("\n===== 8c. PORTAL API (pax-api enforcement control plane) =====\n")
+	for _, ep := range p.Raw.PaxAPI {
+		if ep.Error != "" {
+			fmt.Fprintf(&b, "  %-40s ERR %s\n", ep.Path, ep.Error)
+			continue
+		}
+		fmt.Fprintf(&b, "  %-40s %d %s%s\n", ep.Path, ep.StatusCode, ep.ContentType,
+			truncMark(ep.Truncated))
+	}
+
+	b.WriteString("\n===== HOLES FOUND (ranked; each maps to a nowifi technique) =====\n")
+	if len(p.Holes) == 0 {
+		b.WriteString("  none detected — portal enforcement is tight on every probed vector\n")
+	}
+	for _, h := range p.Holes {
+		fmt.Fprintf(&b, "\n  [%s] %s\n       what : %s\n", h.Severity, h.Technique, h.Detail)
+	}
+
+	if len(p.Raw.Limitations) > 0 {
+		b.WriteString("\n===== LIMITATIONS (degraded / privilege-gated / timed-out) =====\n")
+		for _, l := range p.Raw.Limitations {
+			fmt.Fprintf(&b, "  - %s\n", l)
+		}
+	}
+	return b.String()
+}
+
+func truncMark(t bool) string {
+	if t {
+		return " [body truncated]"
+	}
+	return ""
+}
+
+// Baseline renders the capture-at-full-access baseline file. It records every
+// channel that is open right now, so a later under-enforcement run can diff
+// against it (channels open in both = reliable holes).
+func (p *Package) Baseline() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# nowifi forensic baseline (full-access capture) — %s\n", p.TS)
+	fmt.Fprintf(&b, "# iface=%s gw=%s provider=%s\n", p.Iface, p.GW, p.Provider)
+	b.WriteString("# open channels at baseline (diff a later capture against these)\n\n")
+	for _, h := range p.Holes {
+		fmt.Fprintf(&b, "%s|%s|%s\n", h.Technique, h.Severity, h.Detail)
+	}
+	return b.String()
+}
+
+// ParseBaseline reads a baseline file produced by Baseline() back into holes,
+// for diffing. Lines are "technique|severity|detail"; comments and blanks are
+// skipped. Tolerant of the shell script's baseline files too (best-effort).
+func ParseBaseline(content string) []Hole {
+	var holes []Hole
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		h := Hole{Technique: strings.TrimSpace(parts[0]), Severity: strings.TrimSpace(parts[1])}
+		if len(parts) == 3 {
+			h.Detail = strings.TrimSpace(parts[2])
+		}
+		if h.Technique == "" {
+			continue
+		}
+		holes = append(holes, h)
+	}
+	return holes
+}

--- a/go/internal/forensics/writer.go
+++ b/go/internal/forensics/writer.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package forensics
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteResult records the on-disk paths produced by a write.
+type WriteResult struct {
+	TextPath     string
+	JSONPath     string
+	BaselinePath string
+}
+
+// WriteOptions controls which artifacts Write emits.
+type WriteOptions struct {
+	// Format selects which report files to write: "both" (default), "json",
+	// or "txt". An empty string is treated as "both".
+	Format string
+	// Baseline additionally writes a baseline-<ts>.txt capture-at-full-access
+	// file for later diffing.
+	Baseline bool
+}
+
+// Write persists the package to disk in dir as sibling files,
+// holes-<ts>.txt and holes-<ts>.json (matching the shell script's naming),
+// and returns the saved paths. This is LOCAL-ONLY: it writes to disk and
+// never uploads or phones home.
+//
+// The Format option controls which report files are written; the default
+// ("both") writes both. If opts.Baseline is true, it additionally writes a
+// baseline-<ts>.txt file.
+func (p *Package) Write(dir string, opts WriteOptions) (WriteResult, error) {
+	var res WriteResult
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return res, fmt.Errorf("create output dir: %w", err)
+	}
+
+	wantTxt := opts.Format != "json"
+	wantJSON := opts.Format != "txt"
+
+	if wantTxt {
+		txtPath := filepath.Join(dir, "holes-"+p.TS+".txt")
+		if err := os.WriteFile(txtPath, []byte(p.Text()), 0o600); err != nil {
+			return res, fmt.Errorf("write text report: %w", err)
+		}
+		res.TextPath = txtPath
+	}
+
+	if wantJSON {
+		js, err := p.JSON()
+		if err != nil {
+			return res, fmt.Errorf("marshal json: %w", err)
+		}
+		jsonPath := filepath.Join(dir, "holes-"+p.TS+".json")
+		if err := os.WriteFile(jsonPath, js, 0o600); err != nil {
+			return res, fmt.Errorf("write json report: %w", err)
+		}
+		res.JSONPath = jsonPath
+	}
+
+	if opts.Baseline {
+		basePath := filepath.Join(dir, "baseline-"+p.TS+".txt")
+		if err := os.WriteFile(basePath, []byte(p.Baseline()), 0o600); err != nil {
+			return res, fmt.Errorf("write baseline: %w", err)
+		}
+		res.BaselinePath = basePath
+	}
+
+	return res, nil
+}
+
+// ReadBaselineFile loads and parses a baseline file from disk for diffing.
+func ReadBaselineFile(path string) ([]Hole, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read baseline file: %w", err)
+	}
+	return ParseBaseline(string(data)), nil
+}


### PR DESCRIPTION
## What

Adds a `nowifi forensics` subcommand that captures a portable, read-only
diagnostic package of which egress channels survive captive-portal enforcement,
so an unsolved environment can be analyzed offline to build a working bypass.
This is the operator's #1 requested feature and a Go port of the proven
`forensics/captive-forensics.sh`.

## What it captures (sections 1-10 + pax-api)

1. Network state (DNS, IPv6 default, topology / cross-subnet portal)
2. Authenticated-device enumeration — ARP table = MAC-clone candidates
3. Egress channel sweep under enforcement (TCP/UDP)
4. DNS external recursion (per-resolver)
5. DoH endpoints
6. ICMP echo to the internet
7. Allowlist + SNI / domain-fronting probes
8/8c. Portal/Kong surface + **pax-api enforcement control plane** — fetches
   `/pax-api-service/{session,device,status,quota,plans,health,api-docs,swagger.json}`
   and `/portal-versions.json`, capturing status + body truncated to ~2KB each;
   **swagger.json is captured fully** (it is the enforcement model)
9. Enforcement model (your MAC, per-MAC quota reset vector)
10. Baseline diff support (`--baseline` / `--baseline-file`)

Open channels are mapped to the nowifi technique taxonomy (`dns_tunnel`,
`doh_tunnel`, `icmp_tunnel`, `mac_clone_idle`, `ssh_egress`,
`portal_api_session`, ...) and ranked HIGH/MED/LOW, mirroring the reference
`holes-*.json` shape `{ts, provider, iface, gw, holes[]}` plus raw sections.

## Guarantees

- **Read-only**: no MAC changes, no tunnels, no proxy, no network mutation. The
  ARP MAC-clone enumeration reads the existing cache (no active /24 sweep).
- **No sudo**: runs without root; privilege-gated probes degrade gracefully and
  the limitation is recorded in the package.
- **Local-only**: writes `holes-<UTC-ts>.txt` + `holes-<UTC-ts>.json` to disk
  and prints the paths. Never uploads, never phones home (telemetry stays
  opt-in by invariant).
- **Hard time cap**: default 90s (`--timeout`), per-request pax timeouts ~7s.
  On timeout the package is genuinely partial — completed sections are salvaged.

## Auto-trigger

When a full bypass exhausts with zero success, the audit flow auto-emits a
forensic package (both failure sites in `audit.go`). Best-effort, non-fatal,
runs off the session-maintain loop, and reuses the probes already in scope (no
fresh sweep).

## Reuse

Built on existing `probe.*` (`ProbeAll`, `ProbeTopology`), `platform.*`
(`GetARPTable`, `GetCurrentMAC`, `GetGateway`), and `detect.DetectPortal`. No
reimplemented probing, no new heavy deps (stdlib + existing internal packages).

## DoD

Run in `go/`:

- `gofmt -l .` — new forensics files are clean. (Note: the literal command also
  lists pre-existing files that already fail gofmt on `master`@d963b72; those
  are untouched here and not part of this change.)
- `go vet ./...` — clean.
- `go test ./...` — **1786 passed in 25 packages** (includes new table-driven,
  network-free forensics + CLI tests).
- `GOOS=linux GOARCH=amd64 go build ./...` — success.

Tests cover hole mapping/ranking, baseline diff, JSON/text serialization,
pax-api truncation + full-swagger capture, the timeout-salvage path, and CLI
format/baseline wiring — all without live network via injected probe results
and `httptest` fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
