### PR TITLE
feat(report): automatic consent-gated deferred GitHub-issue report on bypass failure

### DIFF
--- a/go/internal/cli/audit.go
+++ b/go/internal/cli/audit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MikkoParkkola/nowifi/internal/bypass"
 	"github.com/MikkoParkkola/nowifi/internal/capture"
 	"github.com/MikkoParkkola/nowifi/internal/detect"
+	"github.com/MikkoParkkola/nowifi/internal/failreport"
 	"github.com/MikkoParkkola/nowifi/internal/forensics"
 	"github.com/MikkoParkkola/nowifi/internal/guard"
 	"github.com/MikkoParkkola/nowifi/internal/platform"
@@ -113,6 +114,14 @@ func buildBypassConfig(portalInfo *detect.PortalInfo, stealth bool) *bypass.Conf
 // Flow: WiFi info -> portal detection -> leak probing -> interactive choice -> bypass -> report.
 func runAudit(cmd *cobra.Command, args []string) {
 	startTime := time.Now()
+
+	// Automatic, consent-gated report flow: after this run completes, if we
+	// have real internet and there are queued unsolved-network reports, offer
+	// to file each as a GitHub issue (sanitized, with explicit consent). This
+	// is a no-op when offline, when nothing is queued, or when disabled in
+	// config — so it is safe on every invocation. Deferred so it runs after
+	// the TUI exits (clean terminal for the prompt).
+	defer func() { _ = failreport.MaybeOfferPending(os.Stdin, os.Stdout) }()
 
 	// When --fast is set, disable stealth.
 	stealth := flagStealth
@@ -550,6 +559,17 @@ func emitForensicsOnExhaustion(p *tea.Program, iface string, stealth bool, probe
 			return
 		}
 		p.Send(statusMsg{text: fmt.Sprintf("Bypass exhausted — forensic package saved: %s", res.JSONPath)})
+
+		// Queue the package for a consent-gated GitHub issue. We are offline
+		// now (bypass failed), so it is filed later when internet returns.
+		// Best-effort; never fatal to the audit flow.
+		ssid := ""
+		if wi, werr := platform.GetWifiInfo(iface); werr == nil && wi != nil {
+			ssid = wi.SSID
+		}
+		if _, eqErr := failreport.Enqueue(pkg, ssid); eqErr == nil {
+			p.Send(statusMsg{text: "Queued — you'll be asked to submit a GitHub issue next time you're online."})
+		}
 	}()
 }
 

--- a/go/internal/cli/report.go
+++ b/go/internal/cli/report.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MikkoParkkola/nowifi/internal/failreport"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reportList   bool
+	reportDryRun bool
+	reportYes    bool
+)
+
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Review and submit queued unsolved-network forensic reports",
+	Long: `Review and submit forensic reports captured when nowifi could not bypass a
+captive portal.
+
+When bypass fails you are offline, so the forensic package is queued locally.
+The next time nowifi runs with internet it automatically offers to file a
+GitHub issue (with your consent) — you normally never need this command. Use it
+to review pending reports, preview exactly what would be posted, or submit
+non-interactively.
+
+  nowifi report             # interactive: preview + consent prompt per report
+  nowifi report --list      # list pending reports (no submit)
+  nowifi report --dry-run   # print the sanitized issue body (no submit)
+  nowifi report --yes       # submit all pending without prompting (scripted)
+
+Privacy: nearby device MACs and your own MAC are redacted to vendor IDs before
+anything is posted. Filing uses your own authenticated 'gh' CLI; nothing is
+ever uploaded without an explicit confirmation.`,
+	Run: runReport,
+}
+
+func init() {
+	reportCmd.Flags().BoolVar(&reportList, "list", false, "List pending reports without submitting")
+	reportCmd.Flags().BoolVar(&reportDryRun, "dry-run", false, "Print the sanitized issue body without submitting")
+	reportCmd.Flags().BoolVarP(&reportYes, "yes", "y", false, "Submit all pending reports without prompting")
+}
+
+func runReport(cmd *cobra.Command, args []string) {
+	entries, err := failreport.List()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "report: %v\n", err)
+		os.Exit(1)
+	}
+	var pending []failreport.Entry
+	for _, e := range entries {
+		if !e.Submitted {
+			pending = append(pending, e)
+		}
+	}
+
+	if len(pending) == 0 {
+		fmt.Println("No pending unsolved-network reports.")
+		return
+	}
+
+	switch {
+	case reportList:
+		fmt.Printf("%d pending report(s):\n", len(pending))
+		for _, e := range pending {
+			fmt.Printf("  %s  provider=%s ssid=%s  %d open channels\n",
+				e.TS, dash(e.Provider), dash(e.SSID), e.HolesCount)
+		}
+	case reportDryRun:
+		for _, e := range pending {
+			pkg, ent, lerr := failreport.Load(e.ID)
+			if lerr != nil {
+				continue
+			}
+			san := failreport.Sanitize(pkg)
+			fmt.Printf("===== %s =====\nTitle: %s\n\n%s\n",
+				e.TS, failreport.IssueTitle(san, ent.SSID), failreport.IssueBody(san, ent.SSID))
+		}
+	case reportYes:
+		for _, e := range pending {
+			url, body, serr := failreport.SubmitEntry(e.ID)
+			if serr != nil {
+				fmt.Printf("%s: could not file (%v). Create manually at https://github.com/MikkoParkkola/nowifi/issues/new\n\n%s\n", e.TS, serr, body)
+				continue
+			}
+			fmt.Printf("Filed: %s\n", url)
+		}
+	default:
+		// Interactive: the same consent flow used automatically on a connected run.
+		if err := failreport.MaybeOfferPending(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "report: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/go/internal/cli/root.go
+++ b/go/internal/cli/root.go
@@ -138,6 +138,7 @@ func init() {
 	rootCmd.AddCommand(watchCmd)
 	rootCmd.AddCommand(scoreCmd)
 	rootCmd.AddCommand(forensicsCmd)
+	rootCmd.AddCommand(reportCmd)
 }
 
 // loadConfigDefaults fills unset CLI flags from ~/.nowifi/config.json.

--- a/go/internal/cli/watch.go
+++ b/go/internal/cli/watch.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MikkoParkkola/nowifi/internal/bypass"
 	"github.com/MikkoParkkola/nowifi/internal/detect"
+	"github.com/MikkoParkkola/nowifi/internal/failreport"
 	"github.com/MikkoParkkola/nowifi/internal/guard"
 	"github.com/MikkoParkkola/nowifi/internal/platform"
 	"github.com/MikkoParkkola/nowifi/internal/portal"
@@ -105,7 +106,13 @@ func runWatch(cmd *cobra.Command, args []string) {
 
 		if bypass.HasInternet() {
 			fmt.Printf("  %s  %s  Connected\n", dim(ts), green("OK"))
+			wasDown := disconnectCount > 0
 			disconnectCount = 0
+			// On a connectivity RESTORE transition, offer any queued
+			// unsolved-network reports for consent-gated submission (once).
+			if wasDown {
+				_ = failreport.MaybeOfferPending(os.Stdin, os.Stdout)
+			}
 		} else {
 			disconnectCount++
 			fmt.Printf("  %s  %s  Session expired (attempt %d)\n", dim(ts), red("DOWN"), disconnectCount)

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -41,6 +41,14 @@ type Config struct {
 	SSEServer       string `json:"sse_server,omitempty"`
 	GRPCServer      string `json:"grpc_server,omitempty"`
 	ConnectIPServer string `json:"connectip_server,omitempty"`
+
+	// ReportFailures controls whether nowifi NOTICES queued unsolved-network
+	// forensic reports and PROMPTS to file a GitHub issue when internet is
+	// available. It defaults to true, which does NOT violate the opt-in
+	// telemetry invariant: it only enables the consent prompt — nothing is ever
+	// uploaded without an explicit interactive "y". Set false to disable the
+	// notice entirely. No omitempty: an explicit false must persist.
+	ReportFailures bool `json:"report_failures"`
 }
 
 var (
@@ -66,8 +74,9 @@ func Path() string {
 // Defaults returns the default configuration.
 func Defaults() *Config {
 	return &Config{
-		Interface: "en0",
-		Stealth:   true,
+		Interface:      "en0",
+		Stealth:        true,
+		ReportFailures: true,
 	}
 }
 
@@ -181,6 +190,7 @@ func knownConfigKeys() map[string]struct{} {
 		"sse_server":       {},
 		"grpc_server":      {},
 		"connectip_server": {},
+		"report_failures":  {},
 	}
 }
 

--- a/go/internal/failreport/failreport.go
+++ b/go/internal/failreport/failreport.go
@@ -16,6 +16,7 @@ package failreport
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/nowifi/internal/bypass"
 	"github.com/MikkoParkkola/nowifi/internal/config"
@@ -356,7 +358,9 @@ func ghSubmit(title, body string) (string, error) {
 		return "", err
 	}
 	_ = tmp.Close()
-	cmd := exec.Command("gh", "issue", "create",
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "issue", "create",
 		"--repo", repoSlug, "--title", title, "--body-file", tmp.Name())
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/go/internal/failreport/failreport.go
+++ b/go/internal/failreport/failreport.go
@@ -1,0 +1,418 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+// Package failreport implements the automatic, consent-gated, deferred
+// GitHub-issue reporting pipeline for unsolved captive-portal environments.
+//
+// When nowifi cannot bypass a portal it is, by definition, OFFLINE — so an
+// issue cannot be filed at failure time. Instead the forensic package is
+// queued locally (Enqueue). Later, on any nowifi run that has real internet
+// (or a watch reconnect), MaybeOfferPending surfaces the queued report,
+// shows a privacy-sanitized preview, and asks the user for consent before
+// filing a GitHub issue via their own `gh` CLI. Nothing ever leaves the
+// machine without an explicit interactive "y": the automation is the
+// notice+prompt, never silent network egress.
+package failreport
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/MikkoParkkola/nowifi/internal/bypass"
+	"github.com/MikkoParkkola/nowifi/internal/config"
+	"github.com/MikkoParkkola/nowifi/internal/forensics"
+)
+
+// Entry is the queue metadata for one pending report (meta.json).
+type Entry struct {
+	ID         string `json:"id"` // queue dir name == package timestamp
+	TS         string `json:"ts"`
+	Provider   string `json:"provider"`
+	SSID       string `json:"ssid,omitempty"`
+	Gateway    string `json:"gateway,omitempty"`
+	HolesCount int    `json:"holes_count"`
+	Submitted  bool   `json:"submitted"`
+	IssueURL   string `json:"issue_url,omitempty"`
+
+	dir string // absolute queue dir (not serialized)
+}
+
+// queueDir returns ~/.nowifi/pending-reports.
+func queueDir() string { return filepath.Join(config.Dir(), "pending-reports") }
+
+// submitFunc is the issue-filing implementation; overridable in tests.
+var submitFunc = ghSubmit
+
+// hasInternet reports real connectivity; overridable in tests so the
+// consent-flow logic can be exercised without a live network.
+var hasInternet = bypass.HasInternet
+
+// Enqueue persists the full (unsanitized) forensic package plus metadata to
+// the local queue so it can be filed later when connectivity returns. Storage
+// is local-only and full-fidelity; sanitization happens at issue-generation
+// time, never here.
+func Enqueue(pkg *forensics.Package, ssid string) (string, error) {
+	if pkg == nil {
+		return "", fmt.Errorf("nil package")
+	}
+	id := pkg.TS
+	if id == "" {
+		return "", fmt.Errorf("package has no timestamp")
+	}
+	dir := filepath.Join(queueDir(), id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := writeJSONAtomic(filepath.Join(dir, "package.json"), pkg, 0o600); err != nil {
+		return "", err
+	}
+	meta := &Entry{
+		ID: id, TS: pkg.TS, Provider: pkg.Provider, SSID: ssid,
+		Gateway: pkg.GW, HolesCount: len(pkg.Holes), Submitted: false,
+	}
+	if err := writeJSONAtomic(filepath.Join(dir, "meta.json"), meta, 0o600); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// List returns queued reports, unsubmitted first, newest within each group.
+func List() ([]Entry, error) {
+	root := queueDir()
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Entry
+	for _, de := range ents {
+		if !de.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, de.Name())
+		var m Entry
+		if err := readJSON(filepath.Join(dir, "meta.json"), &m); err != nil {
+			continue // skip malformed entries rather than fail the whole list
+		}
+		m.dir = dir
+		if m.ID == "" {
+			m.ID = de.Name()
+		}
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Submitted != out[j].Submitted {
+			return !out[i].Submitted // unsubmitted first
+		}
+		return out[i].TS > out[j].TS // newest first
+	})
+	return out, nil
+}
+
+// PendingCount returns the number of unsubmitted queued reports.
+func PendingCount() int {
+	es, err := List()
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range es {
+		if !e.Submitted {
+			n++
+		}
+	}
+	return n
+}
+
+// Load returns the full stored package and metadata for a queue id.
+func Load(id string) (*forensics.Package, *Entry, error) {
+	dir := filepath.Join(queueDir(), id)
+	var pkg forensics.Package
+	if err := readJSON(filepath.Join(dir, "package.json"), &pkg); err != nil {
+		return nil, nil, err
+	}
+	var m Entry
+	if err := readJSON(filepath.Join(dir, "meta.json"), &m); err != nil {
+		return nil, nil, err
+	}
+	m.dir = dir
+	return &pkg, &m, nil
+}
+
+// MarkSubmitted records that a report was filed (idempotent).
+func MarkSubmitted(id, issueURL string) error {
+	dir := filepath.Join(queueDir(), id)
+	var m Entry
+	if err := readJSON(filepath.Join(dir, "meta.json"), &m); err != nil {
+		return err
+	}
+	m.Submitted = true
+	m.IssueURL = issueURL
+	return writeJSONAtomic(filepath.Join(dir, "meta.json"), &m, 0o600)
+}
+
+// MaybeOfferPending is the automatic entry point. It is a no-op (no output)
+// when reporting is disabled, when there is no internet, or when nothing is
+// pending — so it is safe to call at the start of every nowifi run. Otherwise
+// it shows a sanitized preview of each pending report and asks for consent
+// before filing. When `in` is not interactive it prints a one-line notice and
+// does not block. Errors are never fatal to the caller.
+func MaybeOfferPending(in io.Reader, out io.Writer) error {
+	cfg, _ := config.Load()
+	if cfg != nil && !cfg.ReportFailures {
+		return nil
+	}
+	if !hasInternet() {
+		return nil
+	}
+	es, err := List()
+	if err != nil {
+		return err
+	}
+	var pending []Entry
+	for _, e := range es {
+		if !e.Submitted {
+			pending = append(pending, e)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	if !isInteractive(in) {
+		fmt.Fprintf(out, "\n%d unsolved-network forensic report(s) pending — run `nowifi report` to review and submit.\n", len(pending))
+		return nil
+	}
+
+	reader := bufio.NewReader(in)
+	for _, e := range pending {
+		pkg, _, err := Load(e.ID)
+		if err != nil {
+			continue
+		}
+		san := Sanitize(pkg)
+		fmt.Fprintf(out, "\nUnsolved network captured %s — provider=%s ssid=%s, %d open channels.\n",
+			e.TS, dashIfEmpty(e.Provider), dashIfEmpty(e.SSID), e.HolesCount)
+		fmt.Fprintf(out, "Filing a GitHub issue (your MAC + nearby device MACs are redacted to vendor IDs) helps build a bypass for this environment.\n")
+		fmt.Fprintf(out, "Submit this report to github.com/%s? [y/N] ", repoSlug)
+		line, _ := reader.ReadString('\n')
+		if !isYes(line) {
+			fmt.Fprintln(out, "Skipped (kept locally).")
+			continue
+		}
+		url, err := submitFunc(IssueTitle(san, e.SSID), IssueBody(san, e.SSID))
+		if err != nil {
+			fmt.Fprintf(out, "Could not file automatically (%v).\nCreate it manually at https://github.com/%s/issues/new — body printed below:\n\n%s\n", err, repoSlug, IssueBody(san, e.SSID))
+			continue
+		}
+		_ = MarkSubmitted(e.ID, url)
+		fmt.Fprintf(out, "Filed: %s\n", url)
+	}
+	return nil
+}
+
+const repoSlug = "MikkoParkkola/nowifi"
+
+// SubmitEntry sanitizes and files a single queued report by id, then marks it
+// submitted. Used by the `nowifi report --yes` non-interactive path. Returns
+// the rendered sanitized body alongside any error so callers can fall back to
+// printing it for manual filing when gh is unavailable.
+func SubmitEntry(id string) (issueURL, body string, err error) {
+	pkg, e, lerr := Load(id)
+	if lerr != nil {
+		return "", "", lerr
+	}
+	san := Sanitize(pkg)
+	body = IssueBody(san, e.SSID)
+	url, serr := submitFunc(IssueTitle(san, e.SSID), body)
+	if serr != nil {
+		return "", body, serr
+	}
+	_ = MarkSubmitted(id, url)
+	return url, body, nil
+}
+
+// --- privacy sanitization ---
+
+var macRE = regexp.MustCompile(`(?i)^([0-9a-f]{1,2}:[0-9a-f]{1,2}:[0-9a-f]{1,2}):[0-9a-f]{1,2}:[0-9a-f]{1,2}:[0-9a-f]{1,2}$`)
+
+// redactMAC keeps the vendor OUI (first three octets) and masks the
+// device-specific half. Non-MAC strings are returned unchanged.
+func redactMAC(s string) string {
+	m := macRE.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return s
+	}
+	return m[1] + ":xx:xx:xx"
+}
+
+// Sanitize deep-copies the package and redacts every MAC (nearby third-party
+// devices in Raw.ARP and the user's own Raw.SelfMAC) to vendor-OUI-only,
+// leaving all solve-it intel (IPs, provider, channels, pax-api) intact.
+func Sanitize(p *forensics.Package) *forensics.Package {
+	if p == nil {
+		return nil
+	}
+	var cp forensics.Package
+	b, _ := json.Marshal(p)
+	_ = json.Unmarshal(b, &cp)
+	for i := range cp.Raw.ARP {
+		cp.Raw.ARP[i].MAC = redactMAC(cp.Raw.ARP[i].MAC)
+	}
+	cp.Raw.SelfMAC = redactMAC(cp.Raw.SelfMAC)
+	return &cp
+}
+
+// --- issue rendering ---
+
+// IssueTitle builds a concise, deduplicable issue title.
+func IssueTitle(p *forensics.Package, ssid string) string {
+	prov := dashIfEmpty(p.Provider)
+	if ssid != "" {
+		prov = fmt.Sprintf("%s (%s)", prov, ssid)
+	}
+	return fmt.Sprintf("Unsolved captive portal: %s — %d open channels", prov, len(p.Holes))
+}
+
+// IssueBody renders the sanitized package as a GitHub issue with all the
+// detail needed to build a bypass. Callers MUST pass a Sanitize()d package.
+func IssueBody(p *forensics.Package, ssid string) string {
+	var b strings.Builder
+	b.WriteString("Automated report from `nowifi` — bypass exhausted; this environment is unsolved.\n\n")
+	b.WriteString("## Environment\n")
+	fmt.Fprintf(&b, "- Provider: `%s`\n", dashIfEmpty(p.Provider))
+	if ssid != "" {
+		fmt.Fprintf(&b, "- SSID: `%s`\n", ssid)
+	}
+	fmt.Fprintf(&b, "- Gateway: `%s`\n", dashIfEmpty(p.GW))
+	fmt.Fprintf(&b, "- Interface: `%s`\n", dashIfEmpty(p.Iface))
+	fmt.Fprintf(&b, "- Captured: `%s`\n\n", p.TS)
+
+	b.WriteString("## Ranked holes (candidate techniques)\n\n")
+	if len(p.Holes) == 0 {
+		b.WriteString("_none found — fully sealed environment_\n\n")
+	} else {
+		b.WriteString("| Severity | Technique | Detail |\n|---|---|---|\n")
+		for _, h := range p.Holes {
+			fmt.Fprintf(&b, "| %s | `%s` | %s |\n", h.Severity, h.Technique, strings.ReplaceAll(h.Detail, "|", "\\|"))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Enforcement control plane (pax-api / portal)\n\n")
+	if len(p.Raw.PaxAPI) == 0 {
+		b.WriteString("_no pax-api endpoints captured_\n\n")
+	} else {
+		b.WriteString("| Endpoint | Status |\n|---|---|\n")
+		for _, e := range p.Raw.PaxAPI {
+			fmt.Fprintf(&b, "| `%s` | %d |\n", e.Path, e.StatusCode)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(p.Raw.Limitations) > 0 {
+		b.WriteString("## Capture limitations\n")
+		for _, l := range p.Raw.Limitations {
+			fmt.Fprintf(&b, "- %s\n", l)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Full machine-readable package\n\n")
+	b.WriteString("<details><summary>holes JSON (sanitized)</summary>\n\n```json\n")
+	js, _ := json.MarshalIndent(p, "", "  ")
+	b.Write(js)
+	b.WriteString("\n```\n</details>\n\n")
+
+	b.WriteString("---\n_MAC device-identifiers redacted to vendor OUI for third-party privacy. Filed via `nowifi report` with user consent._\n")
+	return b.String()
+}
+
+// --- gh submission ---
+
+// ghSubmit files the issue using the user's own authenticated `gh` CLI. No
+// token is bundled or read by nowifi. Returns a sentinel error when gh is
+// unavailable so the caller can fall back to printing the body.
+func ghSubmit(title, body string) (string, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return "", fmt.Errorf("gh CLI not found")
+	}
+	tmp, err := os.CreateTemp("", "nowifi-issue-*.md")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.WriteString(body); err != nil {
+		return "", err
+	}
+	_ = tmp.Close()
+	cmd := exec.Command("gh", "issue", "create",
+		"--repo", repoSlug, "--title", title, "--body-file", tmp.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("gh issue create: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return firstURL(string(out)), nil
+}
+
+// --- helpers ---
+
+func writeJSONAtomic(path string, v any, perm os.FileMode) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func readJSON(path string, v any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+func isInteractive(in io.Reader) bool {
+	f, ok := in.(*os.File)
+	if !ok {
+		return false
+	}
+	st, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return st.Mode()&os.ModeCharDevice != 0
+}
+
+func isYes(line string) bool {
+	s := strings.ToLower(strings.TrimSpace(line))
+	return s == "y" || s == "yes"
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+var urlRE = regexp.MustCompile(`https?://\S+`)
+
+func firstURL(s string) string {
+	return strings.TrimSpace(urlRE.FindString(s))
+}

--- a/go/internal/failreport/failreport_test.go
+++ b/go/internal/failreport/failreport_test.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package failreport
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/nowifi/internal/config"
+	"github.com/MikkoParkkola/nowifi/internal/forensics"
+	"github.com/MikkoParkkola/nowifi/internal/platform"
+)
+
+// fullMACRE matches a complete 6-octet MAC (the thing we must NEVER leak).
+var fullMACRE = regexp.MustCompile(`(?i)\b([0-9a-f]{2}:){5}[0-9a-f]{2}\b`)
+
+func samplePackage() *forensics.Package {
+	return &forensics.Package{
+		TS:       "20260529T182618Z",
+		Provider: "panasonic_nordic_sky",
+		Iface:    "en0",
+		GW:       "172.19.248.1",
+		Holes: []forensics.Hole{
+			{Technique: "mac_clone_idle", Severity: "HIGH", Detail: "34 paid devices"},
+			{Technique: "dns_tunnel", Severity: "HIGH", Detail: "UDP/53 open to 8.8.8.8"},
+		},
+		Raw: forensics.RawSections{
+			ARP: []platform.ArpEntry{
+				{IP: "172.19.248.8", MAC: "82:f8:d8:89:da:ea", Interface: "en0"},
+				{IP: "172.19.248.9", MAC: "7e:95:9d:cb:25:ed", Interface: "en0"},
+			},
+			SelfMAC: "fa:0a:71:0b:ba:19",
+			PaxAPI: []forensics.PaxEndpoint{
+				{Path: "/pax-api-service/swagger.json", StatusCode: 200},
+				{Path: "/pax-api-service/quota", StatusCode: 200},
+			},
+		},
+	}
+}
+
+// TestSanitize_NoFullMACSurvives is the privacy-critical gate: after
+// sanitization no full 6-octet MAC may remain anywhere in the serialized
+// package (ARP third-party devices + the user's own SelfMAC).
+func TestSanitize_NoFullMACSurvives(t *testing.T) {
+	p := samplePackage()
+	san := Sanitize(p)
+
+	// Original must still contain full MACs (we didn't mutate the input).
+	if san == p {
+		t.Fatal("Sanitize returned the same pointer; must deep-copy")
+	}
+	if p.Raw.ARP[0].MAC != "82:f8:d8:89:da:ea" {
+		t.Errorf("input was mutated: %s", p.Raw.ARP[0].MAC)
+	}
+
+	for i, e := range san.Raw.ARP {
+		if fullMACRE.MatchString(e.MAC) {
+			t.Errorf("ARP[%d] still has a full MAC: %s", i, e.MAC)
+		}
+		if !strings.HasSuffix(e.MAC, ":xx:xx:xx") {
+			t.Errorf("ARP[%d] not redacted to OUI: %s", i, e.MAC)
+		}
+	}
+	if fullMACRE.MatchString(san.Raw.SelfMAC) {
+		t.Errorf("SelfMAC still full: %s", san.Raw.SelfMAC)
+	}
+
+	// Belt-and-suspenders: scan the whole serialized issue body.
+	body := IssueBody(san, "Nordic Sky")
+	if fullMACRE.MatchString(body) {
+		t.Errorf("issue body leaks a full MAC:\n%s", body)
+	}
+}
+
+func TestRedactMAC(t *testing.T) {
+	cases := map[string]string{
+		"82:f8:d8:89:da:ea": "82:f8:d8:xx:xx:xx",
+		"fa:0a:71:0b:ba:19": "fa:0a:71:xx:xx:xx",
+		"":                  "",
+		"not-a-mac":         "not-a-mac",
+		"172.19.248.1":      "172.19.248.1",
+	}
+	for in, want := range cases {
+		if got := redactMAC(in); got != want {
+			t.Errorf("redactMAC(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestIssueBody_ContainsSolveItDetail(t *testing.T) {
+	san := Sanitize(samplePackage())
+	body := IssueBody(san, "Nordic Sky")
+	for _, want := range []string{"panasonic_nordic_sky", "Nordic Sky", "mac_clone_idle", "dns_tunnel", "swagger.json", "quota", "172.19.248.1"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("issue body missing %q", want)
+		}
+	}
+	// Third-party device IP kept (useful), but its MAC must be redacted.
+	if strings.Contains(body, "82:f8:d8:89:da:ea") {
+		t.Error("issue body leaked a raw third-party MAC")
+	}
+}
+
+func TestQueueRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	id, err := Enqueue(samplePackage(), "Nordic Sky")
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if PendingCount() != 1 {
+		t.Fatalf("PendingCount=%d want 1", PendingCount())
+	}
+	list, err := List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("List=%v err=%v", list, err)
+	}
+	if list[0].SSID != "Nordic Sky" || list[0].HolesCount != 2 {
+		t.Errorf("meta wrong: %+v", list[0])
+	}
+	pkg, ent, err := Load(id)
+	if err != nil || pkg.Provider != "panasonic_nordic_sky" || ent.SSID != "Nordic Sky" {
+		t.Fatalf("Load mismatch: pkg=%v ent=%v err=%v", pkg, ent, err)
+	}
+	if err := MarkSubmitted(id, "https://github.com/MikkoParkkola/nowifi/issues/1"); err != nil {
+		t.Fatalf("MarkSubmitted: %v", err)
+	}
+	if PendingCount() != 0 {
+		t.Errorf("PendingCount=%d want 0 after submit", PendingCount())
+	}
+	list2, _ := List()
+	if !list2[0].Submitted || list2[0].IssueURL == "" {
+		t.Errorf("submitted state not persisted: %+v", list2[0])
+	}
+}
+
+func TestSubmitEntry_UsesSanitizedBodyAndMarks(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id, _ := Enqueue(samplePackage(), "Nordic Sky")
+
+	var capturedBody string
+	orig := submitFunc
+	submitFunc = func(title, body string) (string, error) {
+		capturedBody = body
+		if !strings.Contains(title, "panasonic_nordic_sky") {
+			t.Errorf("title missing provider: %s", title)
+		}
+		return "https://github.com/MikkoParkkola/nowifi/issues/7", nil
+	}
+	defer func() { submitFunc = orig }()
+
+	url, _, err := SubmitEntry(id)
+	if err != nil {
+		t.Fatalf("SubmitEntry: %v", err)
+	}
+	if url == "" {
+		t.Error("no URL returned")
+	}
+	if fullMACRE.MatchString(capturedBody) {
+		t.Errorf("submitted body leaked a full MAC:\n%s", capturedBody)
+	}
+	if PendingCount() != 0 {
+		t.Errorf("entry not marked submitted")
+	}
+}
+
+func TestMaybeOfferPending_ConsentYesAndNo(t *testing.T) {
+	orig := submitFunc
+	var calls int
+	submitFunc = func(title, body string) (string, error) {
+		calls++
+		return "https://github.com/MikkoParkkola/nowifi/issues/9", nil
+	}
+	defer func() { submitFunc = orig }()
+	origNet := hasInternet
+	hasInternet = func() bool { return true } // deterministic: pretend online
+	defer func() { hasInternet = origNet }()
+
+	// Non-*os.File reader is treated as non-interactive → prints notice,
+	// does not submit. This asserts the no-silent-egress guarantee.
+	t.Run("non-interactive never submits", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		config.InvalidateCache()
+		_, _ = Enqueue(samplePackage(), "Nordic Sky")
+		calls = 0
+		var out bytes.Buffer
+		if err := MaybeOfferPending(strings.NewReader("y\n"), &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if calls != 0 {
+			t.Errorf("submitted without an interactive TTY (calls=%d)", calls)
+		}
+		if PendingCount() != 1 {
+			t.Errorf("report should remain pending")
+		}
+		if !strings.Contains(out.String(), "pending") {
+			t.Errorf("expected a pending notice, got: %q", out.String())
+		}
+	})
+}


### PR DESCRIPTION
## What this does

Closes the loop the operator asked for: when nowifi **can't bypass** a captive portal, it captures a forensic package *and* — with consent — files a GitHub issue containing everything needed to build a solution. Because a failed bypass means you're **offline**, filing is **deferred** until connectivity returns.

## Fully automatic — no command, no switches

```
nowifi  (behind a captive portal it can't crack)
  → forensic package auto-captured + ENQUEUED to ~/.nowifi/pending-reports/

... later, anywhere with working internet ...

nowifi  (any normal run) — or `nowifi watch` reconnect
  → "Unsolved network captured <when> … Submit to github.com/MikkoParkkola/nowifi? [y/N]"
  → y → files the issue via your `gh` CLI, prints the URL
```

The auto-offer is a deferred `MaybeOfferPending` at the end of every `runAudit`, gated by `HasInternet()` + pending-count, so it's a silent no-op when offline / nothing queued / disabled.

## Guarantees

| Constraint | How |
|---|---|
| **Deferred** (offline at failure) | Queue locally on exhaustion; file later when online |
| **Consent required** | Explicit interactive `[y/N]` per report; non-TTY prints a notice and **never** submits — no silent egress. Keeps the opt-in-telemetry invariant (the prompt *is* the opt-in) |
| **Privacy** | ~34 nearby third-party MACs (`Raw.ARP`) + your own `SelfMAC` redacted to vendor OUI **before** any issue body exists; a unit test asserts no full 6-octet MAC survives |
| **No bundled token** | Files via your own authenticated `gh`; falls back to printing body + a create-URL when `gh` is absent |

## Components

- `internal/failreport` — queue, sanitize, issue rendering (all solve-it detail: holes, channels, DNS recursion, DoH/ICMP, allowlist/SNI, pax-api control plane incl. swagger reachability, enforcement model), `gh` submit, `MaybeOfferPending`.
- `internal/cli/report.go` — optional `nowifi report` (`--list` / `--dry-run` / `--yes`); you normally never need it.
- Wiring: `audit.go` enqueue on exhaustion + auto-offer; `watch.go` reconnect offer; `config.ReportFailures` (default true, no `omitempty` so an explicit `false` persists).

## DoD

`gofmt` clean · `go vet ./...` clean · `go test ./...` pass (6 new `failreport` tests incl. the MAC-leak gate + no-silent-egress) · `linux/amd64` cross-compile OK · binary smoke (`nowifi report --help`, empty-queue path) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
