### PR TITLE
docs+config: document forensics/report commands + make report_failures toggleable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ That is it. `nowifi` auto-detects the captive portal, probes for weaknesses, tri
 | `sudo nowifi --connectip-server URL` | CONNECT-IP full IP tunnel (TUN device) |
 | `nowifi diagnose` | Read-only security assessment |
 | `nowifi diagnose -r json` | Assessment as JSON |
+| `nowifi forensics` | Capture a portable forensic package of which egress channels survive enforcement (read-only, no sudo, local-only) |
+| `nowifi report` | Review/submit queued reports from environments nowifi could not bypass (consent-gated GitHub issue) |
 | `nowifi crack` | WPA/WPA2 password cracking (8 techniques) |
 | `nowifi scan` | Scan nearby WiFi networks |
 | `nowifi watch` | Maintain access -- auto-reconnect on session expiry |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ sudo nowifi
 # Read-only assessment (no changes to network)
 nowifi diagnose
 
+# Capture a forensic package when an environment can't be bypassed (read-only)
+nowifi forensics
+
 # WPA password cracking
 sudo nowifi crack
 
@@ -148,6 +151,9 @@ nowifi doctor
 | `nowifi recon -o klm.json` | Passive network fingerprint for contributing provider profiles |
 | `nowifi diagnose` | Read-only security assessment (no changes to network) |
 | `nowifi diagnose -r json -o report.json` | Save diagnosis as JSON file |
+| `nowifi forensics` | Capture a portable forensic package of which channels survive enforcement (read-only, no sudo, local-only `holes-<ts>.{txt,json}`) |
+| `nowifi forensics --baseline` | Capture a full-access baseline to diff against later under enforcement |
+| `nowifi report` | Review and submit queued reports from networks nowifi couldn't bypass (consent-gated GitHub issue, MACs redacted) |
 | `nowifi crack` | 8-technique WPA/WPA2 cracking pipeline (ordered fastest-to-slowest, stops on first recovered password) |
 | `nowifi crack --scan-only` | Scan for WiFi networks without attacking |
 | `nowifi scan` | Scan nearby WiFi networks with signal/security info |
@@ -216,6 +222,19 @@ These work when you're connected to WiFi but stuck behind a captive portal login
 | 33 | **Cloudflare WARP tunnel** | Zero-config — auto-registers free WARP device, tunnels via HTTP/2 CONNECT | Critical |
 | 34 | **Portal self-relay** | Zero-config — tunnels through portal-whitelisted domains (Stripe, Google, Apple) via HTTP/2 CONNECT | Critical |
 | 35 | **TURN relay** | Zero-config — relays through public WebRTC TURN servers on TCP/443, indistinguishable from video calls | High |
+
+### When nowifi can't bypass — the self-improving loop
+
+If every technique fails, nowifi turns the dead end into data. It automatically captures a **forensic package** (which egress channels survived enforcement, the portal's control-plane surface, the ranked candidate techniques) and **queues it locally** — because a failed bypass means you're offline and can't file anything yet.
+
+The next time you run nowifi **with working internet** (or `nowifi watch` reconnects), it asks once:
+
+```
+Unsolved network captured 2026-05-29 — provider=panasonic_nordic_sky, 25 open channels.
+Submit this report to github.com/MikkoParkkola/nowifi? [y/N]
+```
+
+On `y`, it files a GitHub issue containing everything needed to build a bypass for that environment. Nothing is ever uploaded without that explicit consent, and your MAC plus nearby device MACs are redacted to vendor IDs first. Disable with `nowifi config set report_failures false`.
 
 ### Anonymous Telemetry (opt-in, zero-cost)
 

--- a/go/internal/cli/config_cmd.go
+++ b/go/internal/cli/config_cmd.go
@@ -245,6 +245,7 @@ func configEntries() []configEntry {
 		stringEntry("wt_server", "WebTransport tunnel server URL", func(c *cfgpkg.Config) string { return c.WTServer }, func(c *cfgpkg.Config, v string) { c.WTServer = v }, func(c *cfgpkg.Config) { c.WTServer = "" }, platform.ValidateURL),
 		boolEntry("auto_login", "Enable saved portal login automation", func(c *cfgpkg.Config) bool { return c.AutoLogin }, func(c *cfgpkg.Config, v bool) { c.AutoLogin = v }, func(c *cfgpkg.Config) { c.AutoLogin = defaults.AutoLogin }),
 		boolEntry("stealth", "Enable randomized probe timing by default", func(c *cfgpkg.Config) bool { return c.Stealth }, func(c *cfgpkg.Config, v bool) { c.Stealth = v }, func(c *cfgpkg.Config) { c.Stealth = defaults.Stealth }),
+		boolEntry("report_failures", "Offer to file a GitHub issue (with consent) when nowifi cannot bypass a network", func(c *cfgpkg.Config) bool { return c.ReportFailures }, func(c *cfgpkg.Config, v bool) { c.ReportFailures = v }, func(c *cfgpkg.Config) { c.ReportFailures = defaults.ReportFailures }),
 	}
 }
 


### PR DESCRIPTION
Closes the doc + config gaps left by the forensics (#41) and auto-report (#42) PRs.

## Why
- `nowifi forensics` and `nowifi report` shipped undocumented — users/agents had no way to discover them.
- `report_failures` was in the config schema + `knownConfigKeys` but **not** registered as a settable `config set` entry, so `nowifi config set report_failures false` returned "unknown config key". The flag was effectively unreachable.

## Changes
- **README.md**: command-table rows for `nowifi forensics` (+ `--baseline`) and `nowifi report`; a usage example; a **"When nowifi can't bypass — the self-improving loop"** section explaining the deferred, consent-gated, MAC-redacted reporting flow.
- **AGENTS.md**: command-table rows for the two new commands.
- **config_cmd.go**: register a `report_failures` `boolEntry` so it is settable.

## Verified
`go build` OK · `gofmt` clean · `golangci-lint` 0 issues · `cli` + `config` tests pass · functional: `config set report_failures false` then `config get` returns `false` then `set ... true` round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
