### PR TITLE
feat(forensics): pax-api recon analysis — real enforcement API vs SPA fallback

### DIFF
--- a/go/internal/failreport/failreport.go
+++ b/go/internal/failreport/failreport.go
@@ -320,6 +320,20 @@ func IssueBody(p *forensics.Package, ssid string) string {
 			fmt.Fprintf(&b, "| `%s` | %d |\n", e.Path, e.StatusCode)
 		}
 		b.WriteString("\n")
+		if pa := p.Raw.PaxAPIAnalysis; pa != nil {
+			fmt.Fprintf(&b, "**Recon verdict:** real-API=`%v` swagger-openapi=`%v`\n\n", pa.IsRealAPI, pa.SwaggerIsOpenAPI)
+			if len(pa.CandidateResetVectors) > 0 {
+				b.WriteString("Candidate reset vectors (recon only — not attempted):\n")
+				for _, rv := range pa.CandidateResetVectors {
+					fmt.Fprintf(&b, "- `%s`\n", rv)
+				}
+				b.WriteString("\n")
+			}
+			for _, note := range pa.Notes {
+				fmt.Fprintf(&b, "> %s\n", note)
+			}
+			b.WriteString("\n")
+		}
 	}
 
 	if len(p.Raw.Limitations) > 0 {

--- a/go/internal/forensics/collector.go
+++ b/go/internal/forensics/collector.go
@@ -90,6 +90,10 @@ type RawSections struct {
 	Cloudflare probe.HttpsProbeResult  `json:"cloudflare"`
 	// Section 8/8c: portal/Kong surface + pax-api control plane.
 	PaxAPI []PaxEndpoint `json:"pax_api,omitempty"`
+	// PaxAPIAnalysis is the recon verdict over PaxAPI: whether it is a real
+	// enforcement API versus the SPA HTML fallback, plus candidate reset
+	// vectors from a real swagger doc.
+	PaxAPIAnalysis *PaxAPIAnalysis `json:"pax_api_analysis,omitempty"`
 	// Section 9: enforcement model.
 	SelfMAC string `json:"self_mac,omitempty"`
 	// Topology context.
@@ -278,6 +282,7 @@ func Collect(opts Options) *Package {
 		}
 		mu.Lock()
 		raw.PaxAPI = pax
+		raw.PaxAPIAnalysis = AnalyzePaxAPI(pax)
 		if paxLimit != "" {
 			raw.Limitations = append(raw.Limitations, paxLimit)
 		}

--- a/go/internal/forensics/holes.go
+++ b/go/internal/forensics/holes.go
@@ -218,6 +218,15 @@ func (p *Package) Text() string {
 		fmt.Fprintf(&b, "  %-40s %d %s%s\n", ep.Path, ep.StatusCode, ep.ContentType,
 			truncMark(ep.Truncated))
 	}
+	if pa := p.Raw.PaxAPIAnalysis; pa != nil {
+		fmt.Fprintf(&b, "  -> real-API=%v swagger-openapi=%v\n", pa.IsRealAPI, pa.SwaggerIsOpenAPI)
+		for _, rv := range pa.CandidateResetVectors {
+			fmt.Fprintf(&b, "     candidate reset vector: %s\n", rv)
+		}
+		for _, note := range pa.Notes {
+			fmt.Fprintf(&b, "     %s\n", note)
+		}
+	}
 
 	b.WriteString("\n===== HOLES FOUND (ranked; each maps to a nowifi technique) =====\n")
 	if len(p.Holes) == 0 {

--- a/go/internal/forensics/paxapi_analysis.go
+++ b/go/internal/forensics/paxapi_analysis.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package forensics
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// PaxAPIAnalysis is the recon verdict over the captured pax-api control-plane
+// endpoints. Its central job is to answer the question the 2026-05-29 flight
+// raised: are the Panasonic "/pax-api-service/*" 200s a REAL enforcement API
+// (an attack surface worth a quota/session reset), versus just the
+// single-page-app returning index.html for every unknown route (no API
+// surface at all)?
+//
+// It is pure analysis over already-captured responses — no network — so it is
+// fully deterministic and testable from fixtures.
+type PaxAPIAnalysis struct {
+	// IsRealAPI is true when at least one endpoint behaves like a real API
+	// (JSON body / an OpenAPI doc / an auth-gated 401/403) rather than the
+	// SPA HTML fallback.
+	IsRealAPI bool `json:"is_real_api"`
+	// SwaggerIsOpenAPI is true when swagger.json parsed as a genuine OpenAPI /
+	// Swagger document (not the SPA HTML).
+	SwaggerIsOpenAPI bool `json:"swagger_is_openapi"`
+	// EndpointKinds classifies each captured endpoint.
+	EndpointKinds []EndpointKind `json:"endpoint_kinds"`
+	// EnforcementOps lists "METHOD path" operations from a real swagger doc
+	// that touch the device / session / quota / plan surface.
+	EnforcementOps []string `json:"enforcement_ops,omitempty"`
+	// CandidateResetVectors lists mutating operations (POST/PUT/PATCH/DELETE)
+	// on the enforcement surface — the places a quota/session reset would be
+	// attempted next (NOT attempted here; recon only).
+	CandidateResetVectors []string `json:"candidate_reset_vectors,omitempty"`
+	// Notes carries the human-readable verdict + caveats.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// EndpointKind is the classification of one captured pax-api response.
+type EndpointKind struct {
+	Path string `json:"path"`
+	// Kind is one of: openapi-json, json-api, auth-gated, html-spa, error,
+	// error-status, empty, other.
+	Kind string `json:"kind"`
+}
+
+// enforcementMarkers are the path substrings that matter for a quota/session
+// reset bypass on Panasonic-style portals.
+var enforcementMarkers = []string{"device", "session", "quota", "plan"}
+
+// mutatingMethods are HTTP methods that could change enforcement state.
+var mutatingMethods = map[string]bool{
+	"post": true, "put": true, "patch": true, "delete": true,
+}
+
+// AnalyzePaxAPI classifies the captured endpoints and derives the recon
+// verdict. Returns nil when there is nothing to analyze.
+func AnalyzePaxAPI(eps []PaxEndpoint) *PaxAPIAnalysis {
+	if len(eps) == 0 {
+		return nil
+	}
+	a := &PaxAPIAnalysis{}
+	for _, ep := range eps {
+		kind := classifyEndpoint(ep)
+		a.EndpointKinds = append(a.EndpointKinds, EndpointKind{Path: ep.Path, Kind: kind})
+		switch kind {
+		case "json-api", "auth-gated":
+			a.IsRealAPI = true
+		case "openapi-json":
+			a.IsRealAPI = true
+			a.SwaggerIsOpenAPI = true
+			ops, resets := extractSwaggerOps(ep.Body)
+			a.EnforcementOps = append(a.EnforcementOps, ops...)
+			a.CandidateResetVectors = append(a.CandidateResetVectors, resets...)
+		}
+	}
+	sort.Strings(a.EnforcementOps)
+	sort.Strings(a.CandidateResetVectors)
+	a.Notes = verdictNotes(a)
+	return a
+}
+
+// classifyEndpoint decides what a single captured response actually is.
+func classifyEndpoint(ep PaxEndpoint) string {
+	if ep.Error != "" {
+		return "error"
+	}
+	if ep.StatusCode == 401 || ep.StatusCode == 403 {
+		// An auth challenge is a strong signal of a REAL protected API.
+		return "auth-gated"
+	}
+	body := strings.TrimSpace(ep.Body)
+	if ep.StatusCode == 0 && body == "" {
+		return "empty"
+	}
+	ct := strings.ToLower(ep.ContentType)
+	isSwagger := strings.HasSuffix(ep.Path, "swagger.json")
+	if isSwagger && looksLikeOpenAPI(body) {
+		return "openapi-json"
+	}
+	if strings.HasPrefix(body, "<") || strings.Contains(ct, "text/html") {
+		return "html-spa"
+	}
+	if strings.Contains(ct, "json") || strings.HasPrefix(body, "{") || strings.HasPrefix(body, "[") {
+		return "json-api"
+	}
+	if ep.StatusCode >= 400 {
+		return "error-status"
+	}
+	if body == "" {
+		return "empty"
+	}
+	return "other"
+}
+
+// looksLikeOpenAPI reports whether a body is a genuine OpenAPI / Swagger doc.
+func looksLikeOpenAPI(body string) bool {
+	var doc struct {
+		OpenAPI string `json:"openapi"`
+		Swagger string `json:"swagger"`
+	}
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		return false
+	}
+	return doc.OpenAPI != "" || doc.Swagger != ""
+}
+
+// extractSwaggerOps pulls "METHOD path" operations from a real swagger doc that
+// touch the enforcement surface, and the mutating subset as reset candidates.
+func extractSwaggerOps(body string) (ops, resets []string) {
+	var doc struct {
+		Paths map[string]map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		return nil, nil
+	}
+	for path, methods := range doc.Paths {
+		if !hasEnforcementMarker(path) {
+			continue
+		}
+		for method := range methods {
+			m := strings.ToLower(method)
+			if m == "parameters" { // shared params object, not a verb
+				continue
+			}
+			op := strings.ToUpper(m) + " " + path
+			ops = append(ops, op)
+			if mutatingMethods[m] {
+				resets = append(resets, op)
+			}
+		}
+	}
+	return ops, resets
+}
+
+func hasEnforcementMarker(path string) bool {
+	lp := strings.ToLower(path)
+	for _, m := range enforcementMarkers {
+		if strings.Contains(lp, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// verdictNotes renders the human-readable conclusion.
+func verdictNotes(a *PaxAPIAnalysis) []string {
+	var n []string
+	switch {
+	case a.SwaggerIsOpenAPI:
+		n = append(n, "pax-api exposes a REAL OpenAPI spec — a genuine enforcement control plane. Map the device/session/quota operations below for a reset vector.")
+		if len(a.CandidateResetVectors) == 0 {
+			n = append(n, "No mutating enforcement operations found in swagger — a reset may require an auth token / a non-documented endpoint.")
+		}
+	case a.IsRealAPI:
+		n = append(n, "pax-api responds as a real API (JSON / auth-gated) but swagger.json was not a usable OpenAPI doc — probe the device/session/quota endpoints directly for a client-controllable id.")
+	default:
+		n = append(n, "pax-api endpoints all returned the SPA HTML fallback — the '200' responses are client-side routing, NOT a real enforcement control plane. A pax-api quota/session reset is NOT a viable vector here; pursue MAC/tunnel techniques instead.")
+	}
+	return n
+}

--- a/go/internal/forensics/paxapi_analysis_test.go
+++ b/go/internal/forensics/paxapi_analysis_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2026 Mikko Parkkola. All rights reserved.
+// Licensed under AGPL-3.0. See LICENSE file.
+
+package forensics
+
+import (
+	"strings"
+	"testing"
+)
+
+// htmlSPABody mirrors what the 2026-05-29 Finnair flight actually captured:
+// every /pax-api-service/* path returned the single-page-app index.html, not
+// a real API response.
+const htmlSPABody = `<!DOCTYPE html>
+<html lang="en"><head><title>Finnair Nordic Sky</title></head>
+<body><div class="loader-container"></div></body></html>`
+
+// realSwaggerBody is a synthetic-but-realistic OpenAPI doc exposing an
+// enforcement surface with a mutating reset operation.
+const realSwaggerBody = `{
+  "openapi": "3.0.1",
+  "info": {"title": "pax-api", "version": "1"},
+  "paths": {
+    "/pax-api-service/device": {"get": {}, "post": {}},
+    "/pax-api-service/quota": {"get": {}},
+    "/pax-api-service/session": {"delete": {}},
+    "/pax-api-service/unrelated": {"get": {}}
+  }
+}`
+
+func TestAnalyzePaxAPI_SPAFallback_NotViable(t *testing.T) {
+	eps := []PaxEndpoint{
+		{Path: "/pax-api-service/quota", StatusCode: 200, ContentType: "text/html", Body: htmlSPABody},
+		{Path: "/pax-api-service/device", StatusCode: 200, ContentType: "text/html", Body: htmlSPABody},
+		{Path: "/pax-api-service/swagger.json", StatusCode: 200, ContentType: "text/html", Body: htmlSPABody},
+	}
+	a := AnalyzePaxAPI(eps)
+	if a == nil {
+		t.Fatal("nil analysis")
+	}
+	if a.IsRealAPI {
+		t.Error("HTML-only responses must NOT be classified as a real API")
+	}
+	if a.SwaggerIsOpenAPI {
+		t.Error("HTML swagger.json must not be treated as OpenAPI")
+	}
+	if len(a.CandidateResetVectors) != 0 {
+		t.Errorf("no reset vectors expected for SPA fallback, got %v", a.CandidateResetVectors)
+	}
+	joined := strings.Join(a.Notes, " ")
+	if !strings.Contains(joined, "SPA HTML fallback") || !strings.Contains(joined, "NOT a viable vector") {
+		t.Errorf("verdict should declare the SPA fallback non-viable, got: %s", joined)
+	}
+	for _, k := range a.EndpointKinds {
+		if k.Kind != "html-spa" {
+			t.Errorf("%s classified as %s, want html-spa", k.Path, k.Kind)
+		}
+	}
+}
+
+func TestAnalyzePaxAPI_RealSwagger_FindsResetVectors(t *testing.T) {
+	eps := []PaxEndpoint{
+		{Path: "/pax-api-service/swagger.json", StatusCode: 200, ContentType: "application/json", Body: realSwaggerBody},
+		{Path: "/pax-api-service/quota", StatusCode: 200, ContentType: "application/json", Body: `{"remaining":0}`},
+	}
+	a := AnalyzePaxAPI(eps)
+	if !a.IsRealAPI || !a.SwaggerIsOpenAPI {
+		t.Fatalf("expected real OpenAPI; got IsRealAPI=%v Swagger=%v", a.IsRealAPI, a.SwaggerIsOpenAPI)
+	}
+	// POST /device and DELETE /session are mutating enforcement ops.
+	want := map[string]bool{
+		"POST /pax-api-service/device":      false,
+		"DELETE /pax-api-service/session":   false,
+		"GET /pax-api-service/quota":        false,
+		"GET /pax-api-service/device":       false,
+		"DELETE /pax-api-service/unrelated": false, // must be EXCLUDED (no marker)
+	}
+	for _, op := range a.EnforcementOps {
+		if _, ok := want[op]; ok {
+			want[op] = true
+		}
+	}
+	if !want["POST /pax-api-service/device"] || !want["DELETE /pax-api-service/session"] {
+		t.Errorf("missing enforcement ops; got %v", a.EnforcementOps)
+	}
+	// The /unrelated path has no enforcement marker → never an op.
+	for _, op := range a.EnforcementOps {
+		if strings.Contains(op, "unrelated") {
+			t.Errorf("non-enforcement path leaked into ops: %s", op)
+		}
+	}
+	resets := strings.Join(a.CandidateResetVectors, " ")
+	if !strings.Contains(resets, "POST /pax-api-service/device") || !strings.Contains(resets, "DELETE /pax-api-service/session") {
+		t.Errorf("expected mutating ops as reset vectors, got %v", a.CandidateResetVectors)
+	}
+	if strings.Contains(resets, "GET ") {
+		t.Errorf("GET must not be a reset vector: %v", a.CandidateResetVectors)
+	}
+}
+
+func TestAnalyzePaxAPI_AuthGatedIsReal(t *testing.T) {
+	eps := []PaxEndpoint{
+		{Path: "/pax-api-service/device", StatusCode: 403, ContentType: "application/json", Body: `{"error":"forbidden"}`},
+		{Path: "/pax-api-service/swagger.json", StatusCode: 404, ContentType: "text/html", Body: htmlSPABody},
+	}
+	a := AnalyzePaxAPI(eps)
+	if !a.IsRealAPI {
+		t.Error("a 401/403 challenge is a real protected API and must set IsRealAPI")
+	}
+	if a.SwaggerIsOpenAPI {
+		t.Error("404 HTML swagger must not be OpenAPI")
+	}
+}
+
+func TestClassifyEndpoint(t *testing.T) {
+	cases := []struct {
+		ep   PaxEndpoint
+		want string
+	}{
+		{PaxEndpoint{Path: "/x", Error: "timeout"}, "error"},
+		{PaxEndpoint{Path: "/x", StatusCode: 401}, "auth-gated"},
+		{PaxEndpoint{Path: "/x", StatusCode: 200, ContentType: "text/html", Body: "<html>"}, "html-spa"},
+		{PaxEndpoint{Path: "/x", StatusCode: 200, ContentType: "application/json", Body: `{"a":1}`}, "json-api"},
+		{PaxEndpoint{Path: "/x/swagger.json", StatusCode: 200, Body: realSwaggerBody}, "openapi-json"},
+		{PaxEndpoint{Path: "/x", StatusCode: 500, Body: "boom"}, "error-status"},
+		{PaxEndpoint{Path: "/x", StatusCode: 0, Body: ""}, "empty"},
+	}
+	for _, c := range cases {
+		if got := classifyEndpoint(c.ep); got != c.want {
+			t.Errorf("classify(%+v)=%q want %q", c.ep, got, c.want)
+		}
+	}
+}
+
+func TestAnalyzePaxAPI_Empty(t *testing.T) {
+	if AnalyzePaxAPI(nil) != nil {
+		t.Error("nil input should yield nil analysis")
+	}
+}


### PR DESCRIPTION
Builds the `panasonic_pax_api` **recon** layer (not the blind exploit — recon only, per scope-before-treatment).

## The question it answers
The 2026-05-29 Finnair flight captured `/pax-api-service/*` endpoints all returning **200** — but the bodies were the SPA's `index.html`, not JSON. So a swagger.json "200" can be the single-page-app catch-all, *not* an OpenAPI doc. Before anyone designs a quota/session-reset bypass, recon must determine: **is the pax-api a real enforcement API, or just SPA routing noise?**

## What it does
`AnalyzePaxAPI` (pure function over already-captured responses — no network):
- **Classifies** each endpoint: `openapi-json` / `json-api` / `auth-gated` / `html-spa` / `error` / `empty`. A `401/403` counts as a real protected API.
- **`IsRealAPI`** / **`SwaggerIsOpenAPI`** verdict — distinguishes a genuine control plane from the HTML fallback.
- When swagger.json is a real OpenAPI doc: extracts **enforcement operations** (device/session/quota/plan paths) and the **mutating subset** as `CandidateResetVectors` (POST/PUT/PATCH/DELETE) — the places a reset would be tried next, **never attempted here**.
- **Verdict notes**: e.g. *"all returned the SPA HTML fallback — the 200s are client-side routing, NOT a real enforcement control plane; pursue MAC/tunnel techniques instead."*

Rendered in the forensic `.txt`, serialized into the package JSON, and surfaced prominently in the auto-report GitHub issue body — so the next flight's real capture feeds a ready reset-vector analysis instead of a blind guess.

## Verified
Pure, deterministic, tested from fixtures (the flight's **actual** HTML capture + a synthetic real-OpenAPI doc). `gofmt` clean · `golangci-lint` 0 issues · `staticcheck` clean · `go vet` clean · forensics + failreport + cli tests pass · linux/amd64 cross-compile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
