### PR TITLE
Report real version for go-installed binaries

### DIFF
--- a/cmd/nowifi/main.go
+++ b/cmd/nowifi/main.go
@@ -4,13 +4,30 @@
 package main
 
 import (
+	"runtime/debug"
+
 	"github.com/MikkoParkkola/nowifi/internal/cli"
 )
 
-// version is set via -ldflags at build time.
+// version is set via -ldflags at build time (`make build`). `go install`
+// doesn't run the Makefile, so fall back to the module version recorded in
+// the build info — that way go-installed binaries report the real release
+// version instead of "dev".
 var version = "dev"
 
 func main() {
-	cli.SetVersion(version)
+	cli.SetVersion(resolveVersion())
 	cli.Execute()
+}
+
+func resolveVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return version
 }


### PR DESCRIPTION
## Why

Now that `go install github.com/MikkoParkkola/nowifi/cmd/nowifi@latest` works (#53), a go-installed binary reports `dev` for `--version` — `go install` skips the Makefile's `-ldflags -X main.version`. Looks broken to anyone who installs the recommended way.

## What

`resolveVersion()` falls back to `runtime/debug.ReadBuildInfo().Main.Version` when the ldflags value is still `dev`. So:
- `make build` / goreleaser: ldflags wins (unchanged).
- `go install ...@v0.16.2`: reports `v0.16.2` from build info.
- local `go run` / `go build`: build info is `(devel)` → stays `dev` (correct).

## Verification
- `go build ./cmd/nowifi`, `go vet ./cmd/nowifi` pass.
- Ships on the next tag — no dedicated release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)