### PR TITLE
docs: add brew trust step for Homebrew 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Need the actual WiFi password instead? `nowifi crack` runs an ordered 8-techniqu
 ### Homebrew (Recommended)
 
 ```bash
+brew trust --tap MikkoParkkola/tap   # Homebrew 6.0+
 brew install MikkoParkkola/tap/nowifi
 ```
 


### PR DESCRIPTION
Adds the `brew trust --tap MikkoParkkola/tap` step (Homebrew 6.0 tap-trust). Required when HOMEBREW_REQUIRE_TAP_TRUST is set, harmless otherwise. Matches the canonical homebrew-tap README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)